### PR TITLE
chore: add brewfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # Node modules
 node_modules/
 
+#Brewfile
+Brewfile.lock.json
+
 # Logs
 logs
 *.log

--- a/Brewfile
+++ b/Brewfile
@@ -1,0 +1,4 @@
+# Brewfile
+brew "kubectl" # For kubectl
+brew "kustomize" # For kustomize
+brew "helm" # For helm

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ It installs the following services into your local kubernetes cluster:
 
 ## Prerequisites
 
+> OSX users with [Homebrew](https://brew.sh/) installed can install the Prerequisites by running the command `brew bundle`
+
 1. Run kubernetes locally. Here are a few options:
 - [Docker Desktop](https://www.docker.com/products/docker-desktop/): Local
   instance of Docker and k8s.


### PR DESCRIPTION
This pull request primarily focuses on improving the setup process for OSX users by leveraging Homebrew. The major changes include the addition of a `Brewfile` which specifies the necessary dependencies, and an update to the `README.md` file to guide OSX users on how to install these prerequisites.

* [`Brewfile`](diffhunk://#diff-1b33d9c13a9a1b0c5d5bc83697ba7b4d36e6cf45f78184c3a28527ffc4418e2dR1-R4): Added a new file that contains a list of necessary dependencies for the project, including `kubectl`, `kustomize`, and `helm`. This allows OSX users with Homebrew installed to easily setup the required tools.
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R19-R20): Updated the prerequisites section to include instructions for OSX users on how to install the prerequisites using the `brew bundle` command. This simplifies the setup process for these users.