### PR TITLE
refactor(loki): change to otlphttp for native OTEL injestion for Loki 

### DIFF
--- a/apps/default/loki/config.yaml
+++ b/apps/default/loki/config.yaml
@@ -28,8 +28,6 @@ query_range:
   parallelise_shardable_queries: true
 limits_config:
   allow_structured_metadata: true # This is required to allow Loki to handle OpenTelemetry data https://grafana.com/docs/loki/latest/send-data/otel/#loki-configuration
-  reject_old_samples: false
-  reject_old_samples_max_age: 365d
   split_queries_by_interval: 15m # This setting dictates how many parallel queries will be ran. If you are often searching over large time spans having this too low will result in excessive parallel overhead which can work against you depending on resources of the container
   max_query_length: 0 # This allows you to query data over any time range. Default is 30d1h
   tsdb_max_query_parallelism: 32
@@ -41,9 +39,6 @@ limits_config:
           attributes:
             - environment.name
 
-ingester:
-  chunk_idle_period: 3m # This will ensure that chunks are flushed after 3 minutes of inactivity. This is needed when max chunk age is set really high
-  max_chunk_age: 8760h # This is required if you want to push old logs. Chunk age dictates how far apart timestamps for logs of the same stream can be. Only needed when pushing old logs (seed-dora)
 #ruler:
 #  alertmanager_url: http://localhost:9093
 # By default, Loki will send anonymous, but uniquely-identifiable usage and configuration

--- a/apps/default/loki/config.yaml
+++ b/apps/default/loki/config.yaml
@@ -35,7 +35,7 @@ limits_config:
   tsdb_max_query_parallelism: 32
   otlp_config:
     resource_attributes:
-      ignore_defaults: false
+      ignore_defaults: true # ignores any default resource attributes listed in default_resource_attributes_as_index_labels
       attributes_config:
         - action: index_label
           attributes:

--- a/apps/default/loki/config.yaml
+++ b/apps/default/loki/config.yaml
@@ -23,6 +23,13 @@ schema_config:
       index:
         prefix: index_
         period: 24h
+    - from: 2024-04-01
+      object_store: filesystem
+      store: tsdb
+      schema: v13
+      index:
+        prefix: index_
+        period: 24h
 
 query_scheduler:
   max_outstanding_requests_per_tenant: 4096
@@ -33,6 +40,7 @@ query_range:
 limits_config:
   split_queries_by_interval: 15m
   max_query_parallelism: 32
+  allow_structured_metadata: true
 
 #ruler:
 #  alertmanager_url: http://localhost:9093

--- a/apps/default/loki/config.yaml
+++ b/apps/default/loki/config.yaml
@@ -1,8 +1,6 @@
 auth_enabled: false
-
 server:
   http_listen_port: 3100
-
 common:
   path_prefix: /loki
   storage:
@@ -13,24 +11,15 @@ common:
   ring:
     kvstore:
       store: inmemory
-
 schema_config:
   configs:
     - from: 2020-10-24
-      store: boltdb-shipper
-      object_store: filesystem
-      schema: v11
-      index:
-        prefix: index_
-        period: 24h
-    - from: 2024-04-01
-      object_store: filesystem
       store: tsdb
+      object_store: filesystem
       schema: v13
       index:
         prefix: index_
         period: 24h
-
 query_scheduler:
   max_outstanding_requests_per_tenant: 4096
 frontend:
@@ -38,13 +27,25 @@ frontend:
 query_range:
   parallelise_shardable_queries: true
 limits_config:
-  split_queries_by_interval: 15m
-  max_query_parallelism: 32
-  allow_structured_metadata: true
+  allow_structured_metadata: true # This is required to allow Loki to handle OpenTelemetry data https://grafana.com/docs/loki/latest/send-data/otel/#loki-configuration
+  reject_old_samples: false
+  reject_old_samples_max_age: 365d
+  split_queries_by_interval: 15m # This setting dictates how many parallel queries will be ran. If you are often searching over large time spans having this too low will result in excessive parallel overhead which can work against you depending on resources of the container
+  max_query_length: 0 # This allows you to query data over any time range. Default is 30d1h
+  tsdb_max_query_parallelism: 32
+  otlp_config:
+    resource_attributes:
+      ignore_defaults: false
+      attributes_config:
+        - action: index_label
+          attributes:
+            - environment.name
 
+ingester:
+  chunk_idle_period: 3m # This will ensure that chunks are flushed after 3 minutes of inactivity. This is needed when max chunk age is set really high
+  max_chunk_age: 8760h # This is required if you want to push old logs. Chunk age dictates how far apart timestamps for logs of the same stream can be. Only needed when pushing old logs (seed-dora)
 #ruler:
 #  alertmanager_url: http://localhost:9093
-
 # By default, Loki will send anonymous, but uniquely-identifiable usage and configuration
 # analytics to Grafana Labs. These statistics are sent to https://stats.grafana.org/
 #

--- a/apps/default/loki/deployment.yaml
+++ b/apps/default/loki/deployment.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
         - name: loki
-          image: grafana/loki:latest
+          image: grafana/loki:3.1.1
           imagePullPolicy: IfNotPresent
           args:
             - "-config.file=/etc/loki/config.yaml"

--- a/collectors/gateway/colconfig.yaml
+++ b/collectors/gateway/colconfig.yaml
@@ -59,8 +59,8 @@ exporters:
     tls:
       insecure: true
 
-  loki:
-    endpoint: http://loki.loki.svc.cluster.local:3100/loki/api/v1/push
+  otlphttp/loki:
+    endpoint: http://loki.loki.svc.cluster.local:3100/otlp
 
 service:
   extensions: [health_check, pprof, zpages]
@@ -73,7 +73,7 @@ service:
     logs:
       receivers: [otlp]
       processors: [memory_limiter, batch, resource/env]
-      exporters: [debug, loki]
+      exporters: [debug, otlphttp/loki]
 
     traces:
       receivers: [otlp]

--- a/collectors/webhook/colconfig.yaml
+++ b/collectors/webhook/colconfig.yaml
@@ -77,18 +77,6 @@ processors:
           - set(attributes["closed_at"], body["issue"]["closed_at"]) where body["issue"]["closed_at"] != nil
           - set(attributes["topics"], body["repository"]["topics"]) where body["repository"]["topics"] != nil
 
-  attributes/issues:
-    actions:
-      - action: upsert
-        key: loki.attribute.labels
-        value: action, created_at, closed_at, issue_labels, topics
-
-  resource/issues:
-    attributes:
-      - action: upsert
-        key: loki.resource.labels
-        value: environment.name, repository.name, repository.owner
-
   filter/issues:
     error_mode: ignore
     logs:
@@ -113,18 +101,6 @@ processors:
           - set(attributes["topics"], body["repository"]["topics"]) where body["repository"]["topics"] != nil
           - set(attributes["deployment.state"], body["deployment_status"]["state"]) where body["deployment_status"]["state"] != nil
           - set(attributes["deployment.environment"], body["deployment"]["environment"]) where body["deployment"]["environment"] != nil
-
-  attributes/gha-deployments:
-    actions:
-      - action: upsert
-        key: loki.attribute.labels
-        value: deployment.state, deployment.environment, topics
-
-  resource/gha-deployments:
-    attributes:
-      - action: upsert
-        key: loki.resource.labels
-        value: environment.name, repository.name, repository.owner
 
   filter/gha-deployments:
     error_mode: ignore
@@ -156,8 +132,6 @@ service:
       processors:
         - transform/issues
         - filter/issues
-        - attributes/issues
-        - resource/issues
       exporters:
         - debug
         - otlp
@@ -168,8 +142,6 @@ service:
       processors:
         - transform/gha-deployments
         - filter/gha-deployments
-        - attributes/gha-deployments
-        - resource/gha-deployments
       exporters:
         - debug
         - otlp

--- a/collectors/webhook/colconfig.yaml
+++ b/collectors/webhook/colconfig.yaml
@@ -1,7 +1,6 @@
 ---
 extensions:
   health_check:
-    endpoint: 0.0.0.0:13133
 
   pprof:
     endpoint: 0.0.0.0:1777
@@ -13,17 +12,17 @@ receivers:
   ## Webhookevent receiver is used to connect to a GitHub App and receive json event logs
   ## The processors are used to extract/filter all the meaningful data from those logs
   webhookevent:
-    endpoint: "0.0.0.0:8088"
+    endpoint: 0.0.0.0:8088
     path: /events
     health_path: /healthcheck
 
-  # prometheus:
-  #   config:
-  #     scrape_configs:
-  #       - job_name: otel-webhook-collector
-  #         scrape_interval: 10s
-  #         static_configs:
-  #           - targets: [0.0.0.0:8888]
+  prometheus:
+    config:
+      scrape_configs:
+        - job_name: otel-webhook-collector
+          scrape_interval: 10s
+          static_configs:
+            - targets: [0.0.0.0:8888]
 
 processors:
   memory_limiter:
@@ -33,105 +32,81 @@ processors:
 
   batch:
     send_batch_size: 100
-    timeout: 11s
+    timeout: 10s
 
-  transform/timestamp:
-    error_mode: propagate
-    log_statements:
-      - context: log
-        statements:
-          - set(time_unix_nano, UnixNano(Time(attributes["created_at"], "%FT%TZ"))) where attributes["created_at"] != nil
+  # filter/ottl:
+  #   error_mode: ignore
+  #   metrics:
+  #     metric:
+  #       - name == "rpc.server.duration"
 
-  ############################################
-  # GitHub Issue Events
-  ############################################
-  transform/body:
+  # transform:
+  #   metric_statements:
+  #     - context: metric
+  #       statements:
+  #         - set(description, "") where name == "queueSize"
+  #         - set(description, "") where name == "http.client.duration"
+
+  #
+  # transform/pull_requests:
+  #   log_statements:
+  #     - context: log
+  #       statements:
+  #         - merge_maps(attributes, ParseJSON(body), "upsert")
+  #         - set(attributes["title"], attributes["pull_request"]["title"]) where attributes["pull_request"]["title"] != nil
+  #         - set(attributes["merged_at"], attributes["pull_request"]["merged_at"]) where attributes["pull_request"]["merged_at"] != nil
+  #         - set(attributes["sha"], attributes["pull_request"]["merge_commit_sha"]) where attributes["pull_request"]["merge_commit_sha"] != nil
+  #         - set(attributes["repository.name"], attributes["repository"]["name"]) where attributes["repository"]["name"] != nil
+  #         - set(attributes["repository.owner"], attributes["repository"]["owner"]["login"]) where attributes["repository"]["owner"]["login"] != nil
+  #         - set(attributes["action"], attributes["action"]) where attributes["action"] != nil
+
+  # Issue transformation to get LogRecord Events from GitHub
+  transform/issues:
     log_statements:
       - context: log
         statements:
           - set(body, ParseJSON(body)) where body != nil
-
-  transform/issue:
-    log_statements:
-      - context: log
-        statements:
           - keep_keys(body, ["issue", "action", "resources", "instrumentation_scope", "repository"])
           - keep_keys(body["repository"], ["name", "full_name", "owner", "topics"]) where body["repository"] != nil
           - keep_keys(body["repository"]["owner"], ["login"]) where body["repository"]["owner"] != nil
           - keep_keys(body["issue"], ["created_at", "closed_at", "labels", "number", "repository_url", "state"]) where body["issue"] != nil
-          - set(attributes["repository_name"], body["repository"]["name"]) where body["repository"]["name"] != nil
-          - set(attributes["repository_owner"], body["repository"]["owner"]["login"]) where body["repository"]["owner"]["login"] != nil
+          - set(attributes["repository.name"], body["repository"]["name"]) where body["repository"]["name"] != nil
+          - set(attributes["repository.owner"], body["repository"]["owner"]["login"]) where body["repository"]["owner"]["login"] != nil
           - set(attributes["action"], body["action"]) where body["action"] != nil
           - set(attributes["created_at"], body["issue"]["created_at"]) where body["issue"]["created_at"] != nil
           - set(attributes["closed_at"], body["issue"]["closed_at"]) where body["issue"]["closed_at"] != nil
           - set(attributes["topics"], body["repository"]["topics"]) where body["repository"]["topics"] != nil
-          - set(attributes["team_name"], body["repository"]["name"]) where body["repository"]["name"] != nil
-          - set(attributes["environment_name"], body["deployment"]["environment"]) where body["deployment"]["environment"] != nil
 
   filter/issues:
     error_mode: ignore
     logs:
       log_record:
-        - 'not IsMatch(body["issue"], ".*")'
+        - not IsMatch(body, "issue")
+        # - not IsMatch(body, "issue") or not IsMatch(body, "deployment")
 
-  ############################################
-  # GitHub Action Deployment Events
-  ############################################
-  transform/deployments:
+  transform/gha-deployments:
     log_statements:
       - context: log
         statements:
-          - keep_keys(body, ["deployment", "deployment_status", "workflow", "worflow_run", "repository"])
-          - keep_keys(body["deployment"], ["url", "id", "task", "environment", "created_at", "updated_at", "sha", "ref"]) where body["deployment"] != nil
-          - keep_keys(body["deployment_status"], ["state", "url", "environment", "created_at"]) where body["deployment_status"] != nil
+          - set(body, ParseJSON(body)) where body != nil
+          - keep_keys(body, ["deployment", "sha", "ref", "deployment_status", "workflow", "worflow_run", "topics", "repository"])
+          - keep_keys(body["deployment"], ["url", "id", "task", "environment", "created_at", "updated_at"]) where body["deployment"] != nil
+          - keep_keys(body["deployment_status"], ["state", "url", "environment"]) where body["deployment_status"] != nil
           - keep_keys(body["workflow"], ["name", "path", "url"]) where body["workflow"] != nil
           - keep_keys(body["workflow_run"], ["head_branch", "head_sha", "display_title", "run_number", "status", "workflow_id"]) where body["workflow_run"] != nil
-          - keep_keys(body["repository"], ["name", "full_name", "owner", "topics"]) where body["repository"] != nil
+          - keep_keys(body["repository"], ["name", "full_name", "owner"]) where body["repository"] != nil
           - keep_keys(body["repository"]["owner"], ["login"]) where body["repository"]["owner"] != nil
-          - set(attributes["repository_name"], body["repository"]["name"]) where body["repository"]["name"] != nil
-          - set(attributes["repository_owner"], body["repository"]["owner"]["login"]) where body["repository"]["owner"]["login"] != nil
+          - set(attributes["repository.name"], body["repository"]["name"]) where body["repository"]["name"] != nil
+          - set(attributes["repository.owner"], body["repository"]["owner"]["login"]) where body["repository"]["owner"]["login"] != nil
           - set(attributes["topics"], body["repository"]["topics"]) where body["repository"]["topics"] != nil
-          - set(attributes["created_at"], body["deployment_status"]["created_at"]) where body["deployment_status"]["created_at"] != nil
-          - set(attributes["deployment_state"], body["deployment_status"]["state"]) where body["deployment_status"]["state"] != nil
-          - set(attributes["deployment_environment"], body["deployment"]["environment"]) where body["deployment"]["environment"] != nil
-          - set(attributes["historical"], "true")
-          - set(attributes["team_name"], body["repository"]["name"]) where body["repository"]["name"] != nil
-          - set(attributes["environment_name"], body["deployment"]["environment"]) where body["deployment"]["environment"] != nil
-          - set(body["deployment"]["created_at"], body["deployment_status"]["created_at"]) where body["deployment_status"]["created_at"] != nil
+          - set(attributes["deployment.state"], body["deployment_status"]["state"]) where body["deployment_status"]["state"] != nil
+          - set(attributes["deployment.environment"], body["deployment"]["environment"]) where body["deployment"]["environment"] != nil
 
-  filter/deployments:
+  filter/gha-deployments:
     error_mode: ignore
     logs:
       log_record:
-        - 'not IsMatch(body["deployment"], ".*")'
-
-  ############################################
-  # GitHub Pull Request Events
-  ############################################
-
-  transform/pull_requests:
-    log_statements:
-      - context: log
-        statements:
-          - keep_keys(body, ["action", "pull_request", "number", "resources", "instrumentation_scope", "repository"])
-          - keep_keys(body["pull_request"], ["title", "user", "created_at", "merged_at", "merged", "merge_commit_sha"]) where body["pull_request"] != nil
-          - keep_keys(body["pull_request"]["user"], ["login"]) where body["pull_request"]["user"] != nil
-          - keep_keys(body["repository"], ["name", "full_name", "topics"]) where body["repository"] != nil
-          - set(attributes["repository_name"], body["repository"]["name"]) where body["repository"]["name"] != nil
-          - set(attributes["action"], body["action"]) where body["action"] != nil
-          - set(attributes["created_at"], body["pull_request"]["merged_at"]) where body["pull_request"]["merged_at"] != nil
-          - set(attributes["merged_at"], body["pull_request"]["merged_at"]) where body["pull_request"]["merged_at"] != nil
-          - set(attributes["merge_sha"], body["pull_request"]["merge_commit_sha"]) where body["pull_request"]["merge_commit_sha"] != nil
-          - set(attributes["topics"], body["repository"]["topics"]) where body["repository"]["topics"] != nil
-          - set(attributes["team_name"], body["repository"]["name"]) where body["repository"]["name"] != nil
-          - set(attributes["environment_name"], body["deployment"]["environment"]) where body["deployment"]["environment"] != nil
-          - set(body["pull_request"]["created_at"], body["deployment_status"]["merged_at"]) where body["deployment_status"]["merged_at"] != nil
-
-  filter/pull_requests:
-    error_mode: ignore
-    logs:
-      log_record:
-        - 'not IsMatch(body["pull_request"], ".*")'
+        - not IsMatch(body, "deployment")
 
 exporters:
   debug:
@@ -143,10 +118,8 @@ exporters:
     endpoint: http://gateway-collector.collector.svc.cluster.local:4317
     tls:
       insecure: true
+
 service:
-  telemetry:
-    logs:
-      level: debug
   extensions:
     - health_check
     - pprof
@@ -157,34 +130,23 @@ service:
       receivers:
         - webhookevent
       processors:
-        - transform/body
+        - transform/issues
         - filter/issues
-        - transform/issue
-        # - transform/timestamp
       exporters:
-        # - debug
+        - debug
         - otlp
 
-    logs/deployments:
+    logs/gha-deployments:
       receivers:
         - webhookevent
       processors:
-        - transform/body
-        - filter/deployments
-        - transform/deployments
-        - transform/timestamp
+        - transform/gha-deployments
+        - filter/gha-deployments
       exporters:
-        # - debug
+        - debug
         - otlp
-
-    logs/pull-requests:
-      receivers:
-        - webhookevent
-      processors:
-        - transform/body
-        - filter/pull_requests
-        - transform/pull_requests
-        # - transform/timestamp
-      exporters:
-        # - debug
-        - otlp
+#
+#    logs/pull_requests:
+#      receivers: [webhookevent]
+#      processors: [transform/pull_requests, attributes/pull_requests, filter/pull_requests]
+#      exporters: [debug, otlp]

--- a/collectors/webhook/colconfig.yaml
+++ b/collectors/webhook/colconfig.yaml
@@ -1,6 +1,7 @@
 ---
 extensions:
   health_check:
+    endpoint: 0.0.0.0:13133
 
   pprof:
     endpoint: 0.0.0.0:1777
@@ -12,17 +13,17 @@ receivers:
   ## Webhookevent receiver is used to connect to a GitHub App and receive json event logs
   ## The processors are used to extract/filter all the meaningful data from those logs
   webhookevent:
-    endpoint: 0.0.0.0:8088
+    endpoint: "0.0.0.0:8088"
     path: /events
     health_path: /healthcheck
 
-  prometheus:
-    config:
-      scrape_configs:
-        - job_name: otel-webhook-collector
-          scrape_interval: 10s
-          static_configs:
-            - targets: [0.0.0.0:8888]
+  # prometheus:
+  #   config:
+  #     scrape_configs:
+  #       - job_name: otel-webhook-collector
+  #         scrape_interval: 10s
+  #         static_configs:
+  #           - targets: [0.0.0.0:8888]
 
 processors:
   memory_limiter:
@@ -32,81 +33,105 @@ processors:
 
   batch:
     send_batch_size: 100
-    timeout: 10s
+    timeout: 11s
 
-  # filter/ottl:
-  #   error_mode: ignore
-  #   metrics:
-  #     metric:
-  #       - name == "rpc.server.duration"
+  transform/timestamp:
+    error_mode: propagate
+    log_statements:
+      - context: log
+        statements:
+          - set(time_unix_nano, UnixNano(Time(attributes["created_at"], "%FT%TZ"))) where attributes["created_at"] != nil
 
-  # transform:
-  #   metric_statements:
-  #     - context: metric
-  #       statements:
-  #         - set(description, "") where name == "queueSize"
-  #         - set(description, "") where name == "http.client.duration"
-
-  #
-  # transform/pull_requests:
-  #   log_statements:
-  #     - context: log
-  #       statements:
-  #         - merge_maps(attributes, ParseJSON(body), "upsert")
-  #         - set(attributes["title"], attributes["pull_request"]["title"]) where attributes["pull_request"]["title"] != nil
-  #         - set(attributes["merged_at"], attributes["pull_request"]["merged_at"]) where attributes["pull_request"]["merged_at"] != nil
-  #         - set(attributes["sha"], attributes["pull_request"]["merge_commit_sha"]) where attributes["pull_request"]["merge_commit_sha"] != nil
-  #         - set(attributes["repository.name"], attributes["repository"]["name"]) where attributes["repository"]["name"] != nil
-  #         - set(attributes["repository.owner"], attributes["repository"]["owner"]["login"]) where attributes["repository"]["owner"]["login"] != nil
-  #         - set(attributes["action"], attributes["action"]) where attributes["action"] != nil
-
-  # Issue transformation to get LogRecord Events from GitHub
-  transform/issues:
+  ############################################
+  # GitHub Issue Events
+  ############################################
+  transform/body:
     log_statements:
       - context: log
         statements:
           - set(body, ParseJSON(body)) where body != nil
+
+  transform/issue:
+    log_statements:
+      - context: log
+        statements:
           - keep_keys(body, ["issue", "action", "resources", "instrumentation_scope", "repository"])
           - keep_keys(body["repository"], ["name", "full_name", "owner", "topics"]) where body["repository"] != nil
           - keep_keys(body["repository"]["owner"], ["login"]) where body["repository"]["owner"] != nil
           - keep_keys(body["issue"], ["created_at", "closed_at", "labels", "number", "repository_url", "state"]) where body["issue"] != nil
-          - set(attributes["repository.name"], body["repository"]["name"]) where body["repository"]["name"] != nil
-          - set(attributes["repository.owner"], body["repository"]["owner"]["login"]) where body["repository"]["owner"]["login"] != nil
+          - set(attributes["repository_name"], body["repository"]["name"]) where body["repository"]["name"] != nil
+          - set(attributes["repository_owner"], body["repository"]["owner"]["login"]) where body["repository"]["owner"]["login"] != nil
           - set(attributes["action"], body["action"]) where body["action"] != nil
           - set(attributes["created_at"], body["issue"]["created_at"]) where body["issue"]["created_at"] != nil
           - set(attributes["closed_at"], body["issue"]["closed_at"]) where body["issue"]["closed_at"] != nil
           - set(attributes["topics"], body["repository"]["topics"]) where body["repository"]["topics"] != nil
+          - set(attributes["team_name"], body["repository"]["name"]) where body["repository"]["name"] != nil
+          - set(attributes["environment_name"], body["deployment"]["environment"]) where body["deployment"]["environment"] != nil
 
   filter/issues:
     error_mode: ignore
     logs:
       log_record:
-        - not IsMatch(body, "issue")
-        # - not IsMatch(body, "issue") or not IsMatch(body, "deployment")
+        - 'not IsMatch(body["issue"], ".*")'
 
-  transform/gha-deployments:
+  ############################################
+  # GitHub Action Deployment Events
+  ############################################
+  transform/deployments:
     log_statements:
       - context: log
         statements:
-          - set(body, ParseJSON(body)) where body != nil
-          - keep_keys(body, ["deployment", "sha", "ref", "deployment_status", "workflow", "worflow_run", "topics", "repository"])
-          - keep_keys(body["deployment"], ["url", "id", "task", "environment", "created_at", "updated_at"]) where body["deployment"] != nil
-          - keep_keys(body["deployment_status"], ["state", "url", "environment"]) where body["deployment_status"] != nil
+          - keep_keys(body, ["deployment", "deployment_status", "workflow", "worflow_run", "repository"])
+          - keep_keys(body["deployment"], ["url", "id", "task", "environment", "created_at", "updated_at", "sha", "ref"]) where body["deployment"] != nil
+          - keep_keys(body["deployment_status"], ["state", "url", "environment", "created_at"]) where body["deployment_status"] != nil
           - keep_keys(body["workflow"], ["name", "path", "url"]) where body["workflow"] != nil
           - keep_keys(body["workflow_run"], ["head_branch", "head_sha", "display_title", "run_number", "status", "workflow_id"]) where body["workflow_run"] != nil
-          - keep_keys(body["repository"], ["name", "full_name", "owner"]) where body["repository"] != nil
+          - keep_keys(body["repository"], ["name", "full_name", "owner", "topics"]) where body["repository"] != nil
           - keep_keys(body["repository"]["owner"], ["login"]) where body["repository"]["owner"] != nil
-          - set(attributes["repository.name"], body["repository"]["name"]) where body["repository"]["name"] != nil
-          - set(attributes["repository.owner"], body["repository"]["owner"]["login"]) where body["repository"]["owner"]["login"] != nil
+          - set(attributes["repository_name"], body["repository"]["name"]) where body["repository"]["name"] != nil
+          - set(attributes["repository_owner"], body["repository"]["owner"]["login"]) where body["repository"]["owner"]["login"] != nil
           - set(attributes["topics"], body["repository"]["topics"]) where body["repository"]["topics"] != nil
-          - set(attributes["deployment.state"], body["deployment_status"]["state"]) where body["deployment_status"]["state"] != nil
-          - set(attributes["deployment.environment"], body["deployment"]["environment"]) where body["deployment"]["environment"] != nil
+          - set(attributes["created_at"], body["deployment_status"]["created_at"]) where body["deployment_status"]["created_at"] != nil
+          - set(attributes["deployment_state"], body["deployment_status"]["state"]) where body["deployment_status"]["state"] != nil
+          - set(attributes["deployment_environment"], body["deployment"]["environment"]) where body["deployment"]["environment"] != nil
+          - set(attributes["historical"], "true")
+          - set(attributes["team_name"], body["repository"]["name"]) where body["repository"]["name"] != nil
+          - set(attributes["environment_name"], body["deployment"]["environment"]) where body["deployment"]["environment"] != nil
+          - set(body["deployment"]["created_at"], body["deployment_status"]["created_at"]) where body["deployment_status"]["created_at"] != nil
 
-  filter/gha-deployments:
+  filter/deployments:
     error_mode: ignore
     logs:
       log_record:
-        - not IsMatch(body, "deployment")
+        - 'not IsMatch(body["deployment"], ".*")'
+
+  ############################################
+  # GitHub Pull Request Events
+  ############################################
+
+  transform/pull_requests:
+    log_statements:
+      - context: log
+        statements:
+          - keep_keys(body, ["action", "pull_request", "number", "resources", "instrumentation_scope", "repository"])
+          - keep_keys(body["pull_request"], ["title", "user", "created_at", "merged_at", "merged", "merge_commit_sha"]) where body["pull_request"] != nil
+          - keep_keys(body["pull_request"]["user"], ["login"]) where body["pull_request"]["user"] != nil
+          - keep_keys(body["repository"], ["name", "full_name", "topics"]) where body["repository"] != nil
+          - set(attributes["repository_name"], body["repository"]["name"]) where body["repository"]["name"] != nil
+          - set(attributes["action"], body["action"]) where body["action"] != nil
+          - set(attributes["created_at"], body["pull_request"]["merged_at"]) where body["pull_request"]["merged_at"] != nil
+          - set(attributes["merged_at"], body["pull_request"]["merged_at"]) where body["pull_request"]["merged_at"] != nil
+          - set(attributes["merge_sha"], body["pull_request"]["merge_commit_sha"]) where body["pull_request"]["merge_commit_sha"] != nil
+          - set(attributes["topics"], body["repository"]["topics"]) where body["repository"]["topics"] != nil
+          - set(attributes["team_name"], body["repository"]["name"]) where body["repository"]["name"] != nil
+          - set(attributes["environment_name"], body["deployment"]["environment"]) where body["deployment"]["environment"] != nil
+          - set(body["pull_request"]["created_at"], body["deployment_status"]["merged_at"]) where body["deployment_status"]["merged_at"] != nil
+
+  filter/pull_requests:
+    error_mode: ignore
+    logs:
+      log_record:
+        - 'not IsMatch(body["pull_request"], ".*")'
 
 exporters:
   debug:
@@ -118,8 +143,10 @@ exporters:
     endpoint: http://gateway-collector.collector.svc.cluster.local:4317
     tls:
       insecure: true
-
 service:
+  telemetry:
+    logs:
+      level: debug
   extensions:
     - health_check
     - pprof
@@ -130,23 +157,34 @@ service:
       receivers:
         - webhookevent
       processors:
-        - transform/issues
+        - transform/body
         - filter/issues
+        - transform/issue
+        # - transform/timestamp
       exporters:
-        - debug
+        # - debug
         - otlp
 
-    logs/gha-deployments:
+    logs/deployments:
       receivers:
         - webhookevent
       processors:
-        - transform/gha-deployments
-        - filter/gha-deployments
+        - transform/body
+        - filter/deployments
+        - transform/deployments
+        - transform/timestamp
       exporters:
-        - debug
+        # - debug
         - otlp
-#
-#    logs/pull_requests:
-#      receivers: [webhookevent]
-#      processors: [transform/pull_requests, attributes/pull_requests, filter/pull_requests]
-#      exporters: [debug, otlp]
+
+    logs/pull-requests:
+      receivers:
+        - webhookevent
+      processors:
+        - transform/body
+        - filter/pull_requests
+        - transform/pull_requests
+        # - transform/timestamp
+      exporters:
+        # - debug
+        - otlp


### PR DESCRIPTION
This pull request includes several updates to configuration files for Loki and related services. The key changes involve updating the Loki image version, modifying configuration settings, and adjusting exporters and processors to support OpenTelemetry data.

### Configuration Updates:

* [`apps/default/loki/config.yaml`](diffhunk://#diff-1d393e999079d30f2da80fb97c544b0fd3e0db3f16df3fd6278712ecabf97d87L2-L5): Updated schema store to `tsdb`, schema version to `v13`, and added `allow_structured_metadata` and `otlp_config` settings to support OpenTelemetry data. [[1]](diffhunk://#diff-1d393e999079d30f2da80fb97c544b0fd3e0db3f16df3fd6278712ecabf97d87L2-L5) [[2]](diffhunk://#diff-1d393e999079d30f2da80fb97c544b0fd3e0db3f16df3fd6278712ecabf97d87L16-L39)

### Image Version Update:

* [`apps/default/loki/deployment.yaml`](diffhunk://#diff-bf76f5e4fcada7219992ecef7102547fdd9f1a7b1f507d475f8b512cf311afe5L18-R18): Changed the Loki image version from `latest` to `3.1.1` to ensure stability and compatibility.

### Exporter Adjustments:

* [`collectors/gateway/colconfig.yaml`](diffhunk://#diff-923420e9300d2a2effb096ed24a183f1156f29c50cde5b55cf7de14075c88fdeL62-R63): Updated the Loki exporter endpoint to use `otlphttp/loki` for better integration with OpenTelemetry. [[1]](diffhunk://#diff-923420e9300d2a2effb096ed24a183f1156f29c50cde5b55cf7de14075c88fdeL62-R63) [[2]](diffhunk://#diff-923420e9300d2a2effb096ed24a183f1156f29c50cde5b55cf7de14075c88fdeL76-R76)

### Processor Removal:

* [`collectors/webhook/colconfig.yaml`](diffhunk://#diff-ce0ad1b9f6a6042a397f7cc56f8cac003d00f72158a360bbb2c1ace1193c0bc0L80-L91): Removed `attributes` and `resource` processors for issues and GitHub Actions deployments to streamline the configuration. [[1]](diffhunk://#diff-ce0ad1b9f6a6042a397f7cc56f8cac003d00f72158a360bbb2c1ace1193c0bc0L80-L91) [[2]](diffhunk://#diff-ce0ad1b9f6a6042a397f7cc56f8cac003d00f72158a360bbb2c1ace1193c0bc0L117-L128) [[3]](diffhunk://#diff-ce0ad1b9f6a6042a397f7cc56f8cac003d00f72158a360bbb2c1ace1193c0bc0L159-L160) [[4]](diffhunk://#diff-ce0ad1b9f6a6042a397f7cc56f8cac003d00f72158a360bbb2c1ace1193c0bc0L171-L172)