### PR TITLE
fix: update OTEL Operator CRD to v1beta1

### DIFF
--- a/cluster-infra/otel-operator/kustomization.yaml
+++ b/cluster-infra/otel-operator/kustomization.yaml
@@ -3,5 +3,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - https://github.com/open-telemetry/opentelemetry-operator/releases/download/v0.98.0/opentelemetry-operator.yaml
+  - https://github.com/open-telemetry/opentelemetry-operator/releases/download/v0.107.0/opentelemetry-operator.yaml
   - rbac.yaml

--- a/collectors/base/collector.yaml
+++ b/collectors/base/collector.yaml
@@ -1,8 +1,8 @@
 ---
-apiVersion: opentelemetry.io/v1alpha1
+apiVersion: opentelemetry.io/v1beta1
 kind: OpenTelemetryCollector
 metadata:
   name: collector
 spec:
-  image: ghcr.io/liatrio/liatrio-otel-collector:0.58.0-amd64
+  image: ghcr.io/liatrio/liatrio-otel-collector:0.66.2-amd64
   mode: deployment

--- a/collectors/gateway-eck/colconfig.yaml
+++ b/collectors/gateway-eck/colconfig.yaml
@@ -1,27 +1,30 @@
-receivers:
-  otlp:
-    protocols:
-      http:
+- op: add
+  path: /spec/config
+  value:
+    receivers:
+      otlp:
+        protocols:
+          http:
 
-processors:
-  memory_limiter:
-    check_interval: 1s
-    limit_mib: 2000
-  batch:
+    processors:
+      memory_limiter:
+        check_interval: 1s
+        limit_mib: 2000
+      batch:
 
-exporters:
-  debug:
-    verbosity: detailed
-  otlphttp:
-    endpoint: "http://eck-stack-apm-server-apm-http.elastic-system.svc:8200"
-    headers:
-      Authorization: "Bearer ${env:secret-token}"
+    exporters:
+      debug:
+        verbosity: detailed
+      otlphttp:
+        endpoint: "http://eck-stack-apm-server-apm-http.elastic-system.svc:8200"
+        headers:
+          Authorization: "Bearer ${env:secret-token}"
 
-service:
-  pipelines:
-    traces:
-      receivers: [otlp]
-      exporters: [debug, otlphttp]
-    metrics:
-      receivers: [otlp]
-      exporters: [debug, otlphttp]
+    service:
+      pipelines:
+        traces:
+          receivers: [otlp]
+          exporters: [debug, otlphttp]
+        metrics:
+          receivers: [otlp]
+          exporters: [debug, otlphttp]

--- a/collectors/gateway-eck/kustomization.yaml
+++ b/collectors/gateway-eck/kustomization.yaml
@@ -13,6 +13,10 @@ patches:
   - target:
       kind: OpenTelemetryCollector
       name: collector
+    path: colconfig.yaml
+  - target:
+      kind: OpenTelemetryCollector
+      name: collector
     patch: |-
       - op: replace
         path: /metadata/name
@@ -26,24 +30,25 @@ patches:
           - secretRef:
               name: eck-stack-apm-server-apm-token
 
-configMapGenerator:
-  - name: collector-config
-    files:
-      - colconfig.yaml
-    options:
-      annotations:
-        config.kubernetes.io/local-config: "true"
+# Config map generator set the collector config as a multi-line string. OTEL operator v1beta1 expects an object rather than a string.
+# configMapGenerator:
+#   - name: collector-config
+#     files:
+#       - colconfig.yaml
+#     options:
+#       annotations:
+#         config.kubernetes.io/local-config: "true"
 
-replacements:
-  - source:
-      kind: ConfigMap
-      name: collector-config
-      fieldPath: data.[colconfig.yaml]
+# replacements:
+#   - source:
+#       kind: ConfigMap
+#       name: collector-config
+#       fieldPath: data.[colconfig.yaml]
 
-    targets:
-      - select:
-          kind: OpenTelemetryCollector
-        fieldPaths:
-          - spec.config
-        options:
-          create: true
+#     targets:
+#       - select:
+#           kind: OpenTelemetryCollector
+#         fieldPaths:
+#           - spec.config
+#         options:
+#           create: true

--- a/collectors/gateway/colconfig.yaml
+++ b/collectors/gateway/colconfig.yaml
@@ -1,81 +1,84 @@
-extensions:
-  health_check:
+- op: add
+  path: /spec/config
+  value:
+    extensions:
+      health_check: {}
 
-  pprof:
-    endpoint: 0.0.0.0:1777
+      pprof:
+        endpoint: 0.0.0.0:1777
 
-  zpages:
-    endpoint: 0.0.0.0:55679
+      zpages:
+        endpoint: 0.0.0.0:55679
 
-receivers:
-  otlp:
-    protocols:
-      grpc:
-      http:
-  prometheus:
-    config:
-      scrape_configs:
-        - job_name: dev-otel-gateway-collector
-          scrape_interval: 10s
-          static_configs:
-            - targets: [0.0.0.0:8888]
-processors:
-  memory_limiter:
-    check_interval: 1s
-    limit_percentage: 75
-    spike_limit_percentage: 15
+    receivers:
+      otlp:
+        protocols:
+          grpc: {}
+          http: {}
+      prometheus:
+        config:
+          scrape_configs:
+            - job_name: dev-otel-gateway-collector
+              scrape_interval: 10s
+              static_configs:
+                - targets: [0.0.0.0:8888]
+    processors:
+      memory_limiter:
+        check_interval: 1s
+        limit_percentage: 75
+        spike_limit_percentage: 15
 
-  batch:
-    send_batch_size: 100
-    timeout: 10s
+      batch:
+        send_batch_size: 100
+        timeout: 10s
 
-  resource/env:
-    attributes:
-      - key: environment.name
-        value: local
-        action: upsert
+      resource/env:
+        attributes:
+          - key: environment.name
+            value: local
+            action: upsert
 
-connectors:
-  spanmetrics:
+    connectors:
+      spanmetrics: {}
 
-exporters:
-  debug:
-    verbosity: basic
-    sampling_initial: 2
-    sampling_thereafter: 500
+    exporters:
+      debug:
+        verbosity: basic
+        sampling_initial: 2
+        sampling_thereafter: 500
 
-  prometheusremotewrite:
-    endpoint: http://prometheus.prometheus.svc.cluster.local:9090/api/v1/write
-    resource_to_telemetry_conversion:
-      enabled: true
+      prometheusremotewrite:
+        endpoint: http://prometheus.prometheus.svc.cluster.local:9090/api/v1/write
+        resource_to_telemetry_conversion:
+          enabled: true
 
-  otlphttp/tempo:
-    endpoint: http://tempo.tempo.svc.cluster.local:4318
-    tls:
-      insecure: true
+      otlphttp/tempo:
+        endpoint: http://tempo.tempo.svc.cluster.local:4318
+        tls:
+          insecure: true
 
-  otlphttp/jaeger:
-    endpoint: http://jaeger-all-in-one-collector.jaeger.svc.cluster.local:4318
-    tls:
-      insecure: true
+      otlphttp/jaeger:
+        endpoint: http://jaeger-all-in-one-collector.jaeger.svc.cluster.local:4318
+        tls:
+          insecure: true
 
-  otlphttp/loki:
-    endpoint: http://loki.loki.svc.cluster.local:3100/otlp
+      otlphttp/loki:
+        endpoint: http://loki.loki.svc.cluster.local:3100/otlp
 
-service:
-  extensions: [health_check, pprof, zpages]
-  pipelines:
-    metrics:
-      receivers: [otlp, spanmetrics]
-      processors: [memory_limiter, batch, resource/env]
-      exporters: [debug, prometheusremotewrite]
+    service:
+      extensions: [health_check, pprof, zpages]
+      pipelines:
+        metrics:
+          receivers: [otlp, spanmetrics]
+          processors: [memory_limiter, batch, resource/env]
+          exporters: [debug, prometheusremotewrite]
 
-    logs:
-      receivers: [otlp]
-      processors: [memory_limiter, batch, resource/env]
-      exporters: [debug, otlphttp/loki]
+        logs:
+          receivers: [otlp]
+          processors: [memory_limiter, batch, resource/env]
+          exporters: [debug, otlphttp/loki]
 
-    traces:
-      receivers: [otlp]
-      processors: [memory_limiter, batch, resource/env]
-      exporters: [debug, otlphttp/tempo, spanmetrics, otlphttp/jaeger]
+        traces:
+          receivers: [otlp]
+          processors: [memory_limiter, batch, resource/env]
+          exporters: [debug, otlphttp/tempo, spanmetrics, otlphttp/jaeger]

--- a/collectors/gateway/kustomization.yaml
+++ b/collectors/gateway/kustomization.yaml
@@ -11,6 +11,10 @@ resources:
   - sa.yaml
 
 patches:
+  - path: colconfig.yaml
+    target:
+      kind: OpenTelemetryCollector
+      name: collector
   - target:
       kind: OpenTelemetryCollector
       name: collector
@@ -22,24 +26,25 @@ patches:
         path: /spec/serviceAccount
         value: otel-collector
 
-configMapGenerator:
-  - name: collector-config
-    files:
-      - colconfig.yaml
-    options:
-      annotations:
-        config.kubernetes.io/local-config: "true"
+# Config map generator set the collector config as a multi-line string. OTEL operator v1beta1 expects an object rather than a string.
+# configMapGenerator:
+#   - name: collector-config
+#     files:
+#       - colconfig.yaml
+#     options:
+#       annotations:
+#         config.kubernetes.io/local-config: "true"
 
-replacements:
-  - source:
-      kind: ConfigMap
-      name: collector-config
-      fieldPath: data.[colconfig.yaml]
+# replacements:
+#   - source:
+#       kind: ConfigMap
+#       name: collector-config
+#       fieldPath: data.[colconfig.yaml]
 
-    targets:
-      - select:
-          kind: OpenTelemetryCollector
-        fieldPaths:
-          - spec.config
-        options:
-          create: true
+#     targets:
+#       - select:
+#           kind: OpenTelemetryCollector
+#         fieldPaths:
+#           - spec.config
+#         options:
+#           create: true

--- a/collectors/gitproviderreceiver/colconfig.yaml
+++ b/collectors/gitproviderreceiver/colconfig.yaml
@@ -1,9 +1,8 @@
-
 - op: add
   path: /spec/config
   value: 
     extensions:
-      health_check:
+      health_check: {}
 
       pprof:
         endpoint: 0.0.0.0:1777

--- a/collectors/gitproviderreceiver/colconfig.yaml
+++ b/collectors/gitproviderreceiver/colconfig.yaml
@@ -1,89 +1,92 @@
----
-extensions:
-  health_check:
 
-  pprof:
-    endpoint: 0.0.0.0:1777
+- op: add
+  path: /spec/config
+  value: 
+    extensions:
+      health_check:
 
-  zpages:
-    endpoint: 0.0.0.0:55679
+      pprof:
+        endpoint: 0.0.0.0:1777
 
-  bearertokenauth/github:
-    token: ${env:GH_PAT}
+      zpages:
+        endpoint: 0.0.0.0:55679
 
-  # bearertokenauth/gitlab:
-  #   token: ${env:GL_PAT}
+      bearertokenauth/github:
+        token: ${env:GH_PAT}
 
-receivers:
-  gitprovider:
-    initial_delay: 10s
-    collection_interval: 300s
-    scrapers:
-      # Default GitHub Scraper Example
-      github:
-        github_org: liatrio
-        search_query: org:liatrio topic:o11y archived:false
-        auth:
-          authenticator: bearertokenauth/github
+      # bearertokenauth/gitlab:
+      #   token: ${env:GL_PAT}
+
+    receivers:
+      gitprovider:
+        initial_delay: 10s
+        collection_interval: 300s
+        scrapers:
+          # Default GitHub Scraper Example
+          github:
+            github_org: liatrio
+            search_query: org:liatrio topic:o11y archived:false
+            auth:
+              authenticator: bearertokenauth/github
+            metrics:
+              git.repository.contributor.count:
+                enabled: true
+              git.repository.cve.count:
+                enabled: true
+          # GitLab scraper example 
+          # gitlab:
+          #   gitlab_org: liatrioinc/subproject
+          #   # search_topic: a topic I'm searching for that's been added to repos
+          #   # search_query: something I'm searching for in code
+          #   auth:
+          #     authenticator: bearertokenauth/gitlab
+          #   metrics:
+          #     git.repository.contributor.count:
+          #       enabled: true
+
+    processors:
+      memory_limiter:
+        check_interval: 1s
+        limit_percentage: 75
+        spike_limit_percentage: 15
+
+      batch:
+        send_batch_size: 100
+        timeout: 10s
+
+      resource/o11y:
+        attributes:
+          - key: team.name
+            # Change this value if you want to associate your scraped repositories
+            # with a different team name
+            value: tag-o11y
+            action: upsert
+
+    exporters:
+      debug:
+        verbosity: basic
+        sampling_initial: 2
+        sampling_thereafter: 500
+
+      otlp:
+        endpoint: http://gateway-collector.collector.svc.cluster.local:4317
+        tls:
+          insecure: true
+
+    service:
+      extensions:
+        - health_check
+        - pprof
+        - zpages
+        - bearertokenauth/github
+      pipelines:
         metrics:
-          git.repository.contributor.count:
-            enabled: true
-          git.repository.cve.count:
-            enabled: true
-      # GitLab scraper example 
-      # gitlab:
-      #   gitlab_org: liatrioinc/subproject
-      #   # search_topic: a topic I'm searching for that's been added to repos
-      #   # search_query: something I'm searching for in code
-      #   auth:
-      #     authenticator: bearertokenauth/gitlab
-      #   metrics:
-      #     git.repository.contributor.count:
-      #       enabled: true
-
-processors:
-  memory_limiter:
-    check_interval: 1s
-    limit_percentage: 75
-    spike_limit_percentage: 15
-
-  batch:
-    send_batch_size: 100
-    timeout: 10s
-
-  resource/o11y:
-    attributes:
-      - key: team.name
-        # Change this value if you want to associate your scraped repositories
-        # with a different team name
-        value: tag-o11y
-        action: upsert
-
-exporters:
-  debug:
-    verbosity: basic
-    sampling_initial: 2
-    sampling_thereafter: 500
-
-  otlp:
-    endpoint: http://gateway-collector.collector.svc.cluster.local:4317
-    tls:
-      insecure: true
-
-service:
-  extensions:
-    - health_check
-    - pprof
-    - zpages
-    - bearertokenauth/github
-  pipelines:
-    metrics:
-      receivers:
-        - gitprovider
-      processors:
-        - memory_limiter
-        - batch
-        - resource/o11y
-      exporters:
-        - debug
-        - otlp
+          receivers:
+            - gitprovider
+          processors:
+            - memory_limiter
+            - batch
+            - resource/o11y
+          exporters:
+            - debug
+            - otlp

--- a/collectors/gitproviderreceiver/kustomization.yaml
+++ b/collectors/gitproviderreceiver/kustomization.yaml
@@ -11,6 +11,10 @@ patches:
   - target:
       kind: OpenTelemetryCollector
       name: collector
+    path: colconfig.yaml
+  - target:
+      kind: OpenTelemetryCollector
+      name: collector
     patch: |-
       - op: replace
         path: /metadata/name
@@ -21,24 +25,25 @@ patches:
           - secretRef:
               name: git-pat
 
-configMapGenerator:
-  - name: collector-config
-    files:
-      - colconfig.yaml
-    options:
-      annotations:
-        config.kubernetes.io/local-config: "true"
+# Config map generator set the collector config as a multi-line string. OTEL operator v1beta1 expects an object rather than a string.
+# configMapGenerator:
+#   - name: collector-config
+#     files:
+#       - colconfig.yaml
+#     options:
+#       annotations:
+#         config.kubernetes.io/local-config: "true"
 
-replacements:
-  - source:
-      kind: ConfigMap
-      name: collector-config
-      fieldPath: data.[colconfig.yaml]
+# replacements:
+#   - source:
+#       kind: ConfigMap
+#       name: collector-config
+#       fieldPath: data.[colconfig.yaml]
 
-    targets:
-      - select:
-          kind: OpenTelemetryCollector
-        fieldPaths:
-          - spec.config
-        options:
-          create: true
+#     targets:
+#       - select:
+#           kind: OpenTelemetryCollector
+#         fieldPaths:
+#           - spec.config
+#         options:
+#           create: true

--- a/collectors/webhook/colconfig.yaml
+++ b/collectors/webhook/colconfig.yaml
@@ -1,152 +1,155 @@
 ---
-extensions:
-  health_check:
+- op: add
+  path: /spec/config
+  value:
+    extensions:
+      health_check: {}
 
-  pprof:
-    endpoint: 0.0.0.0:1777
+      pprof:
+        endpoint: 0.0.0.0:1777
 
-  zpages:
-    endpoint: 0.0.0.0:55679
+      zpages:
+        endpoint: 0.0.0.0:55679
 
-receivers:
-  ## Webhookevent receiver is used to connect to a GitHub App and receive json event logs
-  ## The processors are used to extract/filter all the meaningful data from those logs
-  webhookevent:
-    endpoint: 0.0.0.0:8088
-    path: /events
-    health_path: /healthcheck
+    receivers:
+      ## Webhookevent receiver is used to connect to a GitHub App and receive json event logs
+      ## The processors are used to extract/filter all the meaningful data from those logs
+      webhookevent:
+        endpoint: 0.0.0.0:8088
+        path: /events
+        health_path: /healthcheck
 
-  prometheus:
-    config:
-      scrape_configs:
-        - job_name: otel-webhook-collector
-          scrape_interval: 10s
-          static_configs:
-            - targets: [0.0.0.0:8888]
+      prometheus:
+        config:
+          scrape_configs:
+            - job_name: otel-webhook-collector
+              scrape_interval: 10s
+              static_configs:
+                - targets: [0.0.0.0:8888]
 
-processors:
-  memory_limiter:
-    check_interval: 1s
-    limit_percentage: 75
-    spike_limit_percentage: 15
+    processors:
+      memory_limiter:
+        check_interval: 1s
+        limit_percentage: 75
+        spike_limit_percentage: 15
 
-  batch:
-    send_batch_size: 100
-    timeout: 10s
+      batch:
+        send_batch_size: 100
+        timeout: 10s
 
-  # filter/ottl:
-  #   error_mode: ignore
-  #   metrics:
-  #     metric:
-  #       - name == "rpc.server.duration"
+      # filter/ottl:
+      #   error_mode: ignore
+      #   metrics:
+      #     metric:
+      #       - name == "rpc.server.duration"
 
-  # transform:
-  #   metric_statements:
-  #     - context: metric
-  #       statements:
-  #         - set(description, "") where name == "queueSize"
-  #         - set(description, "") where name == "http.client.duration"
+      # transform:
+      #   metric_statements:
+      #     - context: metric
+      #       statements:
+      #         - set(description, "") where name == "queueSize"
+      #         - set(description, "") where name == "http.client.duration"
 
-  #
-  # transform/pull_requests:
-  #   log_statements:
-  #     - context: log
-  #       statements:
-  #         - merge_maps(attributes, ParseJSON(body), "upsert")
-  #         - set(attributes["title"], attributes["pull_request"]["title"]) where attributes["pull_request"]["title"] != nil
-  #         - set(attributes["merged_at"], attributes["pull_request"]["merged_at"]) where attributes["pull_request"]["merged_at"] != nil
-  #         - set(attributes["sha"], attributes["pull_request"]["merge_commit_sha"]) where attributes["pull_request"]["merge_commit_sha"] != nil
-  #         - set(attributes["repository.name"], attributes["repository"]["name"]) where attributes["repository"]["name"] != nil
-  #         - set(attributes["repository.owner"], attributes["repository"]["owner"]["login"]) where attributes["repository"]["owner"]["login"] != nil
-  #         - set(attributes["action"], attributes["action"]) where attributes["action"] != nil
+      #
+      # transform/pull_requests:
+      #   log_statements:
+      #     - context: log
+      #       statements:
+      #         - merge_maps(attributes, ParseJSON(body), "upsert")
+      #         - set(attributes["title"], attributes["pull_request"]["title"]) where attributes["pull_request"]["title"] != nil
+      #         - set(attributes["merged_at"], attributes["pull_request"]["merged_at"]) where attributes["pull_request"]["merged_at"] != nil
+      #         - set(attributes["sha"], attributes["pull_request"]["merge_commit_sha"]) where attributes["pull_request"]["merge_commit_sha"] != nil
+      #         - set(attributes["repository.name"], attributes["repository"]["name"]) where attributes["repository"]["name"] != nil
+      #         - set(attributes["repository.owner"], attributes["repository"]["owner"]["login"]) where attributes["repository"]["owner"]["login"] != nil
+      #         - set(attributes["action"], attributes["action"]) where attributes["action"] != nil
 
-  # Issue transformation to get LogRecord Events from GitHub
-  transform/issues:
-    log_statements:
-      - context: log
-        statements:
-          - set(body, ParseJSON(body)) where body != nil
-          - keep_keys(body, ["issue", "action", "resources", "instrumentation_scope", "repository"])
-          - keep_keys(body["repository"], ["name", "full_name", "owner", "topics"]) where body["repository"] != nil
-          - keep_keys(body["repository"]["owner"], ["login"]) where body["repository"]["owner"] != nil
-          - keep_keys(body["issue"], ["created_at", "closed_at", "labels", "number", "repository_url", "state"]) where body["issue"] != nil
-          - set(attributes["repository.name"], body["repository"]["name"]) where body["repository"]["name"] != nil
-          - set(attributes["repository.owner"], body["repository"]["owner"]["login"]) where body["repository"]["owner"]["login"] != nil
-          - set(attributes["action"], body["action"]) where body["action"] != nil
-          - set(attributes["created_at"], body["issue"]["created_at"]) where body["issue"]["created_at"] != nil
-          - set(attributes["closed_at"], body["issue"]["closed_at"]) where body["issue"]["closed_at"] != nil
-          - set(attributes["topics"], body["repository"]["topics"]) where body["repository"]["topics"] != nil
+      # Issue transformation to get LogRecord Events from GitHub
+      transform/issues:
+        log_statements:
+          - context: log
+            statements:
+              - set(body, ParseJSON(body)) where body != nil
+              - keep_keys(body, ["issue", "action", "resources", "instrumentation_scope", "repository"])
+              - keep_keys(body["repository"], ["name", "full_name", "owner", "topics"]) where body["repository"] != nil
+              - keep_keys(body["repository"]["owner"], ["login"]) where body["repository"]["owner"] != nil
+              - keep_keys(body["issue"], ["created_at", "closed_at", "labels", "number", "repository_url", "state"]) where body["issue"] != nil
+              - set(attributes["repository.name"], body["repository"]["name"]) where body["repository"]["name"] != nil
+              - set(attributes["repository.owner"], body["repository"]["owner"]["login"]) where body["repository"]["owner"]["login"] != nil
+              - set(attributes["action"], body["action"]) where body["action"] != nil
+              - set(attributes["created_at"], body["issue"]["created_at"]) where body["issue"]["created_at"] != nil
+              - set(attributes["closed_at"], body["issue"]["closed_at"]) where body["issue"]["closed_at"] != nil
+              - set(attributes["topics"], body["repository"]["topics"]) where body["repository"]["topics"] != nil
 
-  filter/issues:
-    error_mode: ignore
-    logs:
-      log_record:
-        - not IsMatch(body, "issue")
-        # - not IsMatch(body, "issue") or not IsMatch(body, "deployment")
+      filter/issues:
+        error_mode: ignore
+        logs:
+          log_record:
+            - not IsMatch(body, "issue")
+            # - not IsMatch(body, "issue") or not IsMatch(body, "deployment")
 
-  transform/gha-deployments:
-    log_statements:
-      - context: log
-        statements:
-          - set(body, ParseJSON(body)) where body != nil
-          - keep_keys(body, ["deployment", "sha", "ref", "deployment_status", "workflow", "worflow_run", "topics", "repository"])
-          - keep_keys(body["deployment"], ["url", "id", "task", "environment", "created_at", "updated_at"]) where body["deployment"] != nil
-          - keep_keys(body["deployment_status"], ["state", "url", "environment"]) where body["deployment_status"] != nil
-          - keep_keys(body["workflow"], ["name", "path", "url"]) where body["workflow"] != nil
-          - keep_keys(body["workflow_run"], ["head_branch", "head_sha", "display_title", "run_number", "status", "workflow_id"]) where body["workflow_run"] != nil
-          - keep_keys(body["repository"], ["name", "full_name", "owner"]) where body["repository"] != nil
-          - keep_keys(body["repository"]["owner"], ["login"]) where body["repository"]["owner"] != nil
-          - set(attributes["repository.name"], body["repository"]["name"]) where body["repository"]["name"] != nil
-          - set(attributes["repository.owner"], body["repository"]["owner"]["login"]) where body["repository"]["owner"]["login"] != nil
-          - set(attributes["topics"], body["repository"]["topics"]) where body["repository"]["topics"] != nil
-          - set(attributes["deployment.state"], body["deployment_status"]["state"]) where body["deployment_status"]["state"] != nil
-          - set(attributes["deployment.environment"], body["deployment"]["environment"]) where body["deployment"]["environment"] != nil
+      transform/gha-deployments:
+        log_statements:
+          - context: log
+            statements:
+              - set(body, ParseJSON(body)) where body != nil
+              - keep_keys(body, ["deployment", "sha", "ref", "deployment_status", "workflow", "worflow_run", "topics", "repository"])
+              - keep_keys(body["deployment"], ["url", "id", "task", "environment", "created_at", "updated_at"]) where body["deployment"] != nil
+              - keep_keys(body["deployment_status"], ["state", "url", "environment"]) where body["deployment_status"] != nil
+              - keep_keys(body["workflow"], ["name", "path", "url"]) where body["workflow"] != nil
+              - keep_keys(body["workflow_run"], ["head_branch", "head_sha", "display_title", "run_number", "status", "workflow_id"]) where body["workflow_run"] != nil
+              - keep_keys(body["repository"], ["name", "full_name", "owner"]) where body["repository"] != nil
+              - keep_keys(body["repository"]["owner"], ["login"]) where body["repository"]["owner"] != nil
+              - set(attributes["repository.name"], body["repository"]["name"]) where body["repository"]["name"] != nil
+              - set(attributes["repository.owner"], body["repository"]["owner"]["login"]) where body["repository"]["owner"]["login"] != nil
+              - set(attributes["topics"], body["repository"]["topics"]) where body["repository"]["topics"] != nil
+              - set(attributes["deployment.state"], body["deployment_status"]["state"]) where body["deployment_status"]["state"] != nil
+              - set(attributes["deployment.environment"], body["deployment"]["environment"]) where body["deployment"]["environment"] != nil
 
-  filter/gha-deployments:
-    error_mode: ignore
-    logs:
-      log_record:
-        - not IsMatch(body, "deployment")
+      filter/gha-deployments:
+        error_mode: ignore
+        logs:
+          log_record:
+            - not IsMatch(body, "deployment")
 
-exporters:
-  debug:
-    verbosity: detailed
-    sampling_initial: 2
-    sampling_thereafter: 500
+    exporters:
+      debug:
+        verbosity: detailed
+        sampling_initial: 2
+        sampling_thereafter: 500
 
-  otlp:
-    endpoint: http://gateway-collector.collector.svc.cluster.local:4317
-    tls:
-      insecure: true
+      otlp:
+        endpoint: http://gateway-collector.collector.svc.cluster.local:4317
+        tls:
+          insecure: true
 
-service:
-  extensions:
-    - health_check
-    - pprof
-    - zpages
+    service:
+      extensions:
+        - health_check
+        - pprof
+        - zpages
 
-  pipelines:
-    logs/issues:
-      receivers:
-        - webhookevent
-      processors:
-        - transform/issues
-        - filter/issues
-      exporters:
-        - debug
-        - otlp
+      pipelines:
+        logs/issues:
+          receivers:
+            - webhookevent
+          processors:
+            - transform/issues
+            - filter/issues
+          exporters:
+            - debug
+            - otlp
 
-    logs/gha-deployments:
-      receivers:
-        - webhookevent
-      processors:
-        - transform/gha-deployments
-        - filter/gha-deployments
-      exporters:
-        - debug
-        - otlp
-#
-#    logs/pull_requests:
-#      receivers: [webhookevent]
-#      processors: [transform/pull_requests, attributes/pull_requests, filter/pull_requests]
-#      exporters: [debug, otlp]
+        logs/gha-deployments:
+          receivers:
+            - webhookevent
+          processors:
+            - transform/gha-deployments
+            - filter/gha-deployments
+          exporters:
+            - debug
+            - otlp
+    #
+    #    logs/pull_requests:
+    #      receivers: [webhookevent]
+    #      processors: [transform/pull_requests, attributes/pull_requests, filter/pull_requests]
+    #      exporters: [debug, otlp]

--- a/collectors/webhook/kustomization.yaml
+++ b/collectors/webhook/kustomization.yaml
@@ -13,6 +13,10 @@ patches:
   - target:
       kind: OpenTelemetryCollector
       name: collector
+    path: colconfig.yaml
+  - target:
+      kind: OpenTelemetryCollector
+      name: collector
     patch: |-
       - op: replace
         path: /metadata/name
@@ -28,24 +32,25 @@ patches:
             protocol: TCP
             targetPort: 8088
 
-configMapGenerator:
-  - name: collector-config
-    files:
-      - colconfig.yaml
-    options:
-      annotations:
-        config.kubernetes.io/local-config: "true"
+# Config map generator set the collector config as a multi-line string. OTEL operator v1beta1 expects an object rather than a string.
+# configMapGenerator:
+#   - name: collector-config
+#     files:
+#       - colconfig.yaml
+#     options:
+#       annotations:
+#         config.kubernetes.io/local-config: "true"
 
-replacements:
-  - source:
-      kind: ConfigMap
-      name: collector-config
-      fieldPath: data.[colconfig.yaml]
+# replacements:
+#   - source:
+#       kind: ConfigMap
+#       name: collector-config
+#       fieldPath: data.[colconfig.yaml]
 
-    targets:
-      - select:
-          kind: OpenTelemetryCollector
-        fieldPaths:
-          - spec.config
-        options:
-          create: true
+#     targets:
+#       - select:
+#           kind: OpenTelemetryCollector
+#         fieldPaths:
+#           - spec.config
+#         options:
+#           create: true


### PR DESCRIPTION
This pull request includes several updates to the OpenTelemetry Collector configurations and Kustomize files to support the latest versions and improve the configuration structure. The most important changes are grouped into version updates and configuration adjustments.

### Version Updates:
* Updated the OpenTelemetry Operator version from `v0.98.0` to `v0.107.0` in `cluster-infra/otel-operator/kustomization.yaml`. This version supports `v1beta1`.
* Updated the `apiVersion` from `opentelemetry.io/v1alpha1` to `opentelemetry.io/v1beta1` and the collector image version from `0.58.0-amd64` to `0.66.2-amd64` in `collectors/base/collector.yaml`.

### Configuration Adjustments:
Currently ConfigMapGenerator set the spec.config of the collectors as a multi-line string. `v1beta1` looks for config objects instead of string which throws errors previously. Instead of generating a config map which each `colconfig.yaml` for the collectors. We patch the configuration with kustomize to generate the proper configuration `v1beta1` of the OTEL CRD is looking for.

CRD Changelog: https://github.com/open-telemetry/opentelemetry-operator/blob/main/docs/crd-changelog.md