### PR TITLE
feat: add scripts to tear down and restart resources

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,3 +105,14 @@ delete-traces:
 	kubectl delete -k ./cluster-infra/otel-operator/ --ignore-not-found
 	kubectl delete -k ./cluster-infra/cert-manager/ --ignore-not-found
 	kubectl delete -f https://github.com/flux-iac/tofu-controller/releases/download/v0.15.1/tf-controller.crds.yaml
+
+.PHONY: tag-o11y-restart
+tag-o11y-restart:
+	@./scripts/tag-o11y-rollback.sh
+	echo "Waiting 10 seconds for everything to spin down"
+	sleep 10
+	make
+
+.PHONY: tag-o11y-rollback
+tag-o11y-rollback:
+	@./scripts/tag-o11y-rollback.sh

--- a/README.md
+++ b/README.md
@@ -30,6 +30,21 @@ It installs the following services into your local kubernetes cluster:
 
 ## Quick Start
 
+Ensure you actually have a cluster running and are on the correct context, in the previous step, you should have installed k3d or setup Docker Desktop for kubernetes.
+
+Using K3D:
+
+```bash
+k3d cluster create mycluster
+kubectl config use-context k3d-mycluster
+```
+
+Using Docker Kubernetes (Assuming Kubenetes in Docker is enabled):
+
+```bash
+kubectl config use-context docker-desktop
+```
+
 To deploy the basic set of configuration with the LGTM stack and a Gateway
 OpenTelemetry Collector, run `make`.
 
@@ -139,6 +154,20 @@ presumes that you have a free NGrok account, an API Key, and an AuthToken.
    > it but you can skip this step if you would like.
 
 ### Cleanup
+
+To restart the Cluster and spin up all resources again use make target `tag-o11y-restart`
+
+```bash
+make tag-o11y-restart
+```
+
+To remove all resources, including the cluster use make target `tag-o11y-rollback`
+
+```bash
+make tag-o11y-rollback
+```
+
+To remove all traces, tofu contoller, and cert-manager use make taget `delete-traces`
 
 ```bash
 make delete-traces

--- a/scripts/tag-o11y-rollback.sh
+++ b/scripts/tag-o11y-rollback.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+# Prompt the user to ensure they want to rollback
+read -p "Are you sure you want to rollback the setup? (Y/N): " response
+if [[ ! "$response" =~ ^[Yy]$ ]]; then
+  echo "Rollback aborted."
+  exit 1
+fi
+
+# Stop port forwarding
+echo "Stopping port forwarding..."
+pkill -f "kubectl port-forward svc/gateway-collector -n collector 4317:4317"
+pkill -f "kubectl port-forward svc/jaeger-all-in-one-query -n jaeger 16686:16686"
+pkill -f "kubectl port-forward svc/grafana -n grafana 3001:3000"
+
+# Function to delete resources and wait for their deletion
+delete_and_wait() {
+  kubectl delete -k $1 --ignore-not-found
+  kubectl wait --for=delete -k $1 --timeout=120s
+}
+
+# Delete resources in reverse order of their creation
+delete_and_wait ./apps/default
+delete_and_wait ./collectors/gateway/
+delete_and_wait ./cluster-infra/rbac/
+delete_and_wait ./cluster-infra/otel-operator/
+delete_and_wait ./cluster-infra/jaeger-operator/
+delete_and_wait ./cluster-infra/cert-manager/
+
+# Delete specific deployments and wait for their deletion
+kubectl delete deployment opentelemetry-operator-controller-manager -n opentelemetry-operator-system --ignore-not-found
+kubectl delete deployment jaeger-operator -n observability --ignore-not-found
+kubectl delete deployment cert-manager -n cert-manager --ignore-not-found
+kubectl delete deployment cert-manager-cainjector -n cert-manager --ignore-not-found
+kubectl delete deployment cert-manager-webhook -n cert-manager --ignore-not-found
+
+# Print URLs for confirmation
+echo "Resources have been deleted. Please verify the following URLs are no longer accessible:"
+echo "Grafana: http://localhost:3000"
+echo "Loki: http://localhost:3100"
+echo "Tempo: http://localhost:4317"
+echo "Prometheus: http://localhost:9090"
+echo "Jaeger: http://localhost:16686"
+
+# Uninstall k3d and kubectl if necessary
+# echo "Uninstalling k3d and kubectl..."
+# brew uninstall k3d
+# brew uninstall kubectl
+
+echo "Rollback completed."


### PR DESCRIPTION
This pull request introduces new commands for managing the Kubernetes cluster and updates the documentation to reflect these changes. It also includes a script for rolling back the observability setup.

New commands and scripts:

* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R108-R118): Added new `tag-o11y-restart` and `tag-o11y-rollback` commands to restart and rollback the observability setup. (`[MakefileR108-R118](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R108-R118)`)
* [`scripts/tag-o11y-rollback.sh`](diffhunk://#diff-51d8bcedb2ceafd7fd785bf7b5a54cd0d857c72964df1000008dfcba6e9659cbR1-R50): Introduced a new script to rollback the observability setup, including stopping port forwarding and deleting resources. (`[scripts/tag-o11y-rollback.shR1-R50](diffhunk://#diff-51d8bcedb2ceafd7fd785bf7b5a54cd0d857c72964df1000008dfcba6e9659cbR1-R50)`)

Documentation updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R33-R47): Added instructions for ensuring the Kubernetes cluster is running and updated with commands for restarting and rolling back the observability setup. (`[[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R33-R47)`, `[[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R158-R171)`)