### PR TITLE
feat: add github receiver collector

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,10 @@ jaeger-operator:
 gpr: default
 	kubectl apply -k ./collectors/gitproviderreceiver/
 
+.PHONY: ghr
+ghr: default
+	kubectl apply -k ./collectors/githubreceiver/
+
 .PHONY: eck-operator
 eck-operator:
 	kubectl apply -k ./cluster-infra/eck-operator/

--- a/README.md
+++ b/README.md
@@ -54,13 +54,21 @@ Below are a couple of examples of what the tilt dashboard provides you.
 
 ## Delivery Metrics
 
-### Git Provider Receiver (GitHub)
+### Git Provider Receiver (GitHub) (Deprecated: Use GitHub Receiver)
 
 To deploy the GitProvider Receiver:
 
 1. Create a GitHub PAT
 2. Create a `./collectors/gitproviderreceiver/.env` file containing `GH_PAT=<your GitHub PAT>`
 3. Run `make gpr`
+
+### GitHub Receiver
+
+To deploy the GitHub Receiver
+
+1. Create a GitHub PAT
+2. Create a `./collectors/githubreceiver/.env` file containing `GH_PAT=<your GitHub PAT>`
+3. Run `make ghr`
 
 ### Git Provider Receiver (GitLab)
 

--- a/collectors/base/collector.yaml
+++ b/collectors/base/collector.yaml
@@ -4,5 +4,5 @@ kind: OpenTelemetryCollector
 metadata:
   name: collector
 spec:
-  image: ghcr.io/liatrio/liatrio-otel-collector:0.66.2-amd64
+  image: ghcr.io/liatrio/liatrio-otel-collector:0.69.0-amd64
   mode: deployment

--- a/collectors/githubreceiver/colconfig.yaml
+++ b/collectors/githubreceiver/colconfig.yaml
@@ -13,9 +13,6 @@
       bearertokenauth/github:
         token: ${env:GH_PAT}
 
-      # bearertokenauth/gitlab:
-      #   token: ${env:GL_PAT}
-
     receivers:
       github:
         initial_delay: 10s
@@ -85,10 +82,5 @@
     - name: GH_PAT
       valueFrom:
         secretKeyRef:
-          name: git-pat
+          name: github-pat
           key: GH_PAT
-    # - name: GH_PAT
-    #   valueFrom:
-    #     secretKeyRef:
-    #       name: git-org
-    #       key: GH_ORG

--- a/collectors/githubreceiver/colconfig.yaml
+++ b/collectors/githubreceiver/colconfig.yaml
@@ -1,0 +1,94 @@
+- op: add
+  path: /spec/config
+  value:
+    extensions:
+      health_check: {}
+
+      pprof:
+        endpoint: 0.0.0.0:1777
+
+      zpages:
+        endpoint: 0.0.0.0:55679
+
+      bearertokenauth/github:
+        token: ${env:GH_PAT}
+
+      # bearertokenauth/gitlab:
+      #   token: ${env:GL_PAT}
+
+    receivers:
+      github:
+        initial_delay: 10s
+        collection_interval: 60s
+        scrapers:
+          github:
+            metrics:
+              #Optional Metrics
+              vcs.repository.contributor.count:
+                enabled: true
+            github_org: liatrio
+            #search_query: org:liatrio topic:o11y archived:false  #Recommended optional query override, defaults to "{org,user}:<github_org>"
+            #endpoint: https://selfmanagedenterpriseserver.com
+            auth:
+              authenticator: bearertokenauth/github
+
+    processors:
+      memory_limiter:
+        check_interval: 1s
+        limit_percentage: 75
+        spike_limit_percentage: 15
+
+      batch:
+        send_batch_size: 100
+        timeout: 10s
+
+      resource/o11y:
+        attributes:
+          - key: team.name
+            # Change this value if you want to associate your scraped repositories
+            # with a different team name
+            value: tag-o11y
+            action: upsert
+
+    exporters:
+      debug:
+        verbosity: normal
+        sampling_initial: 2
+        sampling_thereafter: 500
+
+      otlp:
+        endpoint: http://gateway-collector.collector.svc.cluster.local:4317
+        tls:
+          insecure: true
+
+    service:
+      extensions:
+        - health_check
+        - pprof
+        - zpages
+        - bearertokenauth/github
+      pipelines:
+        metrics:
+          receivers:
+            - github
+          processors:
+            - memory_limiter
+            - batch
+            - resource/o11y
+          exporters:
+            - debug
+            - otlp
+
+- op: add
+  path: /spec/env
+  value: 
+    - name: GH_PAT
+      valueFrom:
+        secretKeyRef:
+          name: git-pat
+          key: GH_PAT
+    # - name: GH_PAT
+    #   valueFrom:
+    #     secretKeyRef:
+    #       name: git-org
+    #       key: GH_ORG

--- a/collectors/githubreceiver/kustomization.yaml
+++ b/collectors/githubreceiver/kustomization.yaml
@@ -11,7 +11,7 @@ generatorOptions:
   disableNameSuffixHash: true
 
 secretGenerator:
-  - name: git-pat
+  - name: github-pat
     envs:
       - .env
 

--- a/collectors/githubreceiver/kustomization.yaml
+++ b/collectors/githubreceiver/kustomization.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: collector
+
+resources:
+  - ../base/
+
+generatorOptions:
+  disableNameSuffixHash: true
+
+secretGenerator:
+  - name: git-pat
+    envs:
+      - .env
+
+patches:
+  - target:
+      kind: OpenTelemetryCollector
+      name: collector
+    path: colconfig.yaml
+  - target:
+      kind: OpenTelemetryCollector
+      name: collector
+    patch: |-
+      - op: replace
+        path: /metadata/name
+        value: githubreceiver


### PR DESCRIPTION
This PR adds the GitHub Receiver Collector to this repository. Since the GitProviderReceiver is no longer, its time to update all repositories that use it.

This PR....
- Adds Make target `make ghr`
- Adds `collector/githubreceiver`
- Updates `README.md`
- Updates `base/collector.yaml` to use [v0.69.0](https://github.com/liatrio/liatrio-otel-collector/releases/tag/v0.69.0) of _Liatrio Otel Collector_. This version of the collector still contains the GitProviderReceiver for grace to those who still use it or are unfamiliar with the new GitHubReceiver. 