### PR TITLE
feat: Add support for bootstraping openobserve with dashboards

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,11 +54,11 @@ gpr:
 
 .PHONY: ghr
 ghr:
-	kubectl apply -k ./collectors/githubreceiver/
+	DEPLOY_GITHUB=true $(MAKE) default
 
 .PHONY: glr
 glr:
-	kubectl apply -k ./collectors/gitlabreceiver/
+	DEPLOY_GITLAB=true $(MAKE) default
 
 .PHONY: eck-operator
 eck-operator:
@@ -75,8 +75,8 @@ eck: cert-manager otel-operator eck-operator
 	kubectl apply -k ./collectors/gateway-eck/
 
 .PHONY: dora
-dora: default
-	kubectl apply -k ./collectors/webhook/
+dora:
+	DEPLOY_WEBHOOK=true $(MAKE) default
 
 .PHONY: ngrok
 ngrok:

--- a/apps/openobserve/README.md
+++ b/apps/openobserve/README.md
@@ -1,0 +1,118 @@
+# OpenObserve
+
+This deployment runs [OpenObserve](https://openobserve.ai/) with automatic dashboard provisioning.
+
+## Quick Start
+
+```bash
+# From the apps/openobserve directory
+tilt up
+```
+
+OpenObserve will be available at http://localhost:5080
+
+**Default credentials:**
+- Email: `root@example.com`
+- Password: `Complexpass#123`
+
+## Dashboard Bootstrapping
+
+OpenObserve does not natively support loading dashboards from files on startup. This deployment uses a Kubernetes Job that calls the OpenObserve API to import dashboards automatically.
+
+### How It Works
+
+1. The `dashboards/` folder contains exported dashboard JSON files
+2. Kustomize packages these into a ConfigMap (`openobserve-dashboards`)
+3. On startup, a bootstrap Job waits for OpenObserve to be healthy
+4. The Job POSTs each dashboard JSON to `/api/{org}/dashboards`
+
+### Adding or Updating Dashboards
+
+#### Step 1: Build your dashboard locally
+
+1. Start the local environment:
+   ```bash
+   tilt up
+   ```
+
+2. Open OpenObserve at http://localhost:5080 and log in
+
+3. Create or modify dashboards using the OpenObserve UI
+
+#### Step 2: Export the dashboard
+
+1. Navigate to **Dashboards** in the OpenObserve UI
+2. Click on the dashboard you want to export
+3. Click the **⋮** (three dots) menu → **Export**
+4. Save the JSON file
+
+#### Step 3: Add to version control
+
+1. Move the exported JSON to the `dashboards/` folder:
+   ```bash
+   mv ~/Downloads/MyDashboard.dashboard.json ./dashboards/my-dashboard.dashboard.json
+   ```
+
+2. Add the file to `kustomization.yaml`:
+   ```yaml
+   configMapGenerator:
+     - name: openobserve-dashboards
+       files:
+         - dashboards/engineering-effectiveness.dashboard.json
+         - dashboards/my-dashboard.dashboard.json  # Add your new dashboard
+   ```
+
+#### Step 4: Reload
+
+If Tilt is running, it will automatically detect the changes and reload. Otherwise:
+
+```bash
+tilt up
+```
+
+The bootstrap Job will re-run and import all dashboards.
+
+### File Structure
+
+```
+apps/openobserve/
+├── README.md
+├── Tiltfile
+├── kustomization.yaml
+├── sts.yaml                      # StatefulSet + Service
+├── secret.yaml                   # Credentials
+├── dashboard-bootstrap-job.yaml  # Import Job
+└── dashboards/
+    └── *.dashboard.json          # Exported dashboards
+```
+
+### Troubleshooting
+
+**Dashboard not appearing?**
+
+Check the bootstrap Job logs:
+```bash
+kubectl logs -n openobserve job/openobserve-dashboard-bootstrap
+```
+
+**Job stuck or failed?**
+
+Delete and let Tilt recreate it:
+```bash
+kubectl delete job openobserve-dashboard-bootstrap -n openobserve
+```
+
+**Duplicate dashboards?**
+
+The API creates a new dashboard each time. If you see duplicates after multiple imports, delete the extras manually in the UI. The Job has `ttlSecondsAfterFinished: 60` so completed jobs are cleaned up automatically.
+
+## Configuration
+
+Credentials are stored in `secret.yaml`. To change them, update the Secret and restart the StatefulSet:
+
+```yaml
+stringData:
+  OO_USER: "your-email@example.com"
+  OO_PASSWORD: "your-password"
+  OO_ORG: "default"
+```

--- a/apps/openobserve/README.md
+++ b/apps/openobserve/README.md
@@ -2,6 +2,15 @@
 
 This deployment runs [OpenObserve](https://openobserve.ai/) with automatic dashboard provisioning.
 
+> [!WARNING]
+> **Why the bootstrap Job hack?**
+>
+> OpenObserve does **not** currently support initializing dashboards from files at startup.
+> This is a known feature request: [openobserve/openobserve#7073](https://github.com/openobserve/openobserve/issues/7073)
+>
+> Until native support is added, we use a Kubernetes Job that POSTs dashboard JSON to the API on startup.
+> Once this feature lands upstream, this workaround can be removed.
+
 ## Quick Start
 
 ```bash

--- a/apps/openobserve/Tiltfile
+++ b/apps/openobserve/Tiltfile
@@ -1,0 +1,27 @@
+if k8s_context() != "k3d-otel-basic":
+  fail("Expected context to be k3d-otel-basic")
+
+k8s_yaml(kustomize("."), allow_duplicates=True)
+
+k8s_resource(
+  workload="openobserve",
+  port_forwards=5080,
+  labels=[
+    "openobserve"
+  ]
+)
+
+# The bootstrap job needs to run after openobserve is up.
+# Delete the old job first so it can be recreated on each Tilt up/reload.
+local_resource(
+  name="cleanup-dashboard-job",
+  cmd="kubectl delete job openobserve-dashboard-bootstrap -n openobserve --ignore-not-found=true",
+  labels=["openobserve"],
+  resource_deps=[]
+)
+
+k8s_resource(
+  workload="openobserve-dashboard-bootstrap",
+  labels=["openobserve"],
+  resource_deps=["openobserve", "cleanup-dashboard-job"]
+)

--- a/apps/openobserve/dashboard-bootstrap-job.yaml
+++ b/apps/openobserve/dashboard-bootstrap-job.yaml
@@ -1,0 +1,69 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: openobserve-dashboard-bootstrap
+  namespace: openobserve
+  labels:
+    app: openobserve-bootstrap
+spec:
+  ttlSecondsAfterFinished: 60
+  backoffLimit: 5
+  template:
+    spec:
+      restartPolicy: OnFailure
+      containers:
+        - name: bootstrap
+          image: curlimages/curl:8.11.0
+          env:
+            - name: OO_BASE_URL
+              value: "http://openobserve.openobserve.svc.cluster.local:5080"
+            - name: OO_ORG
+              valueFrom:
+                secretKeyRef:
+                  name: openobserve-creds
+                  key: OO_ORG
+            - name: OO_USER
+              valueFrom:
+                secretKeyRef:
+                  name: openobserve-creds
+                  key: OO_USER
+            - name: OO_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: openobserve-creds
+                  key: OO_PASSWORD
+          volumeMounts:
+            - name: dashboards
+              mountPath: /dashboards
+          command:
+            - sh
+            - -c
+            - |
+              set -e
+
+              echo "Waiting for OpenObserve to be ready..."
+              until curl -fsS "${OO_BASE_URL}/healthz" >/dev/null 2>&1; do
+                echo "OpenObserve not ready, waiting..."
+                sleep 5
+              done
+              echo "OpenObserve is ready!"
+
+              echo "Importing dashboards from /dashboards..."
+              for f in /dashboards/*.json; do
+                [ -e "$f" ] || continue
+                echo "Importing $f..."
+                if curl -fsS -u "${OO_USER}:${OO_PASSWORD}" \
+                  -H "Content-Type: application/json" \
+                  --data @"$f" \
+                  "${OO_BASE_URL}/api/${OO_ORG}/dashboards"; then
+                  echo "✓ Imported $f"
+                else
+                  echo "✗ Failed to import $f (continuing anyway)"
+                fi
+              done
+              echo "Dashboard import complete!"
+
+      volumes:
+        - name: dashboards
+          configMap:
+            name: openobserve-dashboards

--- a/apps/openobserve/dashboards/engineering-effectiveness.dashboard.json
+++ b/apps/openobserve/dashboards/engineering-effectiveness.dashboard.json
@@ -1,0 +1,496 @@
+{
+  "version": 7,
+  "dashboardId": "7404651743587336192",
+  "title": "Engineering Effectiveness",
+  "description": "",
+  "role": "",
+  "owner": "",
+  "created": "2025-12-10T22:27:19.723Z",
+  "tabs": [
+    {
+      "tabId": "default",
+      "name": "Default",
+      "panels": [
+        {
+          "id": "Panel_ID2528110",
+          "type": "gauge",
+          "title": "Branch Count",
+          "description": "",
+          "config": {
+            "show_legends": true,
+            "legends_position": null,
+            "unit": "numbers",
+            "decimals": 0,
+            "line_thickness": 1.5,
+            "step_value": "0",
+            "top_results_others": false,
+            "axis_border_show": false,
+            "label_option": {
+              "rotate": 0
+            },
+            "show_symbol": false,
+            "line_interpolation": "smooth",
+            "legend_width": {
+              "unit": "px"
+            },
+            "legend_height": {
+              "unit": "px"
+            },
+            "base_map": {
+              "type": "osm"
+            },
+            "map_type": {
+              "type": "world"
+            },
+            "map_view": {
+              "zoom": 1,
+              "lat": 0,
+              "lng": 0
+            },
+            "map_symbol_style": {
+              "size": "by Value",
+              "size_by_value": {
+                "min": 1,
+                "max": 100
+              },
+              "size_fixed": 2
+            },
+            "drilldown": [],
+            "mark_line": [],
+            "override_config": [],
+            "connect_nulls": false,
+            "no_value_replacement": "",
+            "wrap_table_cells": false,
+            "table_transpose": false,
+            "table_dynamic_columns": false,
+            "mappings": [],
+            "color": {
+              "mode": "continuous-green-yellow-red",
+              "fixedColor": [
+                "green",
+                "yellow",
+                "red"
+              ],
+              "seriesBy": "last",
+              "colorBySeries": []
+            },
+            "background": {
+              "type": "single",
+              "value": {
+                "color": "#808080"
+              }
+            },
+            "trellis": {
+              "layout": null,
+              "num_of_columns": 1,
+              "group_by_y_axis": false
+            },
+            "show_gridlines": true
+          },
+          "queryType": "promql",
+          "queries": [
+            {
+              "query": "vcs_ref_count{vcs_repository_name=~\"$repo\"}",
+              "vrlFunctionQuery": "",
+              "customQuery": true,
+              "fields": {
+                "stream": "vcs_ref_count",
+                "stream_type": "metrics",
+                "x": [],
+                "y": [],
+                "z": [],
+                "breakdown": [],
+                "filter": {
+                  "filterType": "group",
+                  "logicalOperator": "AND",
+                  "conditions": []
+                }
+              },
+              "config": {
+                "promql_legend": "{vcs_repository_name}",
+                "layer_type": "scatter",
+                "weight_fixed": 1,
+                "limit": 0,
+                "min": 0,
+                "max": 50,
+                "time_shift": []
+              }
+            }
+          ],
+          "layout": {
+            "x": 96,
+            "y": 18,
+            "w": 96,
+            "h": 18,
+            "i": 1
+          },
+          "htmlContent": "",
+          "markdownContent": "",
+          "customChartContent": " // To know more about ECharts , \n// visit: https://echarts.apache.org/examples/en/index.html \n// Example: https://echarts.apache.org/examples/en/editor.html?c=line-simple \n// Define your ECharts 'option' here. \n// 'data' variable is available for use and contains the response data from the search result and it is an array.\noption = {  \n \n};\n  "
+        },
+        {
+          "id": "Panel_ID1384910",
+          "type": "area-stacked",
+          "title": "Branch Age",
+          "description": "",
+          "config": {
+            "show_legends": true,
+            "legends_position": null,
+            "unit": "seconds",
+            "decimals": 2,
+            "line_thickness": 1.5,
+            "step_value": "0",
+            "top_results_others": false,
+            "axis_border_show": false,
+            "label_option": {
+              "rotate": 0
+            },
+            "show_symbol": false,
+            "line_interpolation": "smooth",
+            "legend_width": {
+              "unit": "px"
+            },
+            "legend_height": {
+              "unit": "px"
+            },
+            "base_map": {
+              "type": "osm"
+            },
+            "map_type": {
+              "type": "world"
+            },
+            "map_view": {
+              "zoom": 1,
+              "lat": 0,
+              "lng": 0
+            },
+            "map_symbol_style": {
+              "size": "by Value",
+              "size_by_value": {
+                "min": 1,
+                "max": 100
+              },
+              "size_fixed": 2
+            },
+            "drilldown": [],
+            "mark_line": [],
+            "override_config": [],
+            "connect_nulls": false,
+            "no_value_replacement": "",
+            "wrap_table_cells": false,
+            "table_transpose": false,
+            "table_dynamic_columns": false,
+            "mappings": [],
+            "color": {
+              "mode": "palette-classic-by-series",
+              "fixedColor": [
+                "#53ca53"
+              ],
+              "seriesBy": "last",
+              "colorBySeries": []
+            },
+            "trellis": {
+              "layout": null,
+              "num_of_columns": 1,
+              "group_by_y_axis": false
+            },
+            "show_gridlines": true
+          },
+          "queryType": "promql",
+          "queries": [
+            {
+              "query": "vcs_ref_time{vcs_repository_name=~\"$repo\"}",
+              "vrlFunctionQuery": "",
+              "customQuery": true,
+              "fields": {
+                "stream": "vcs_ref_time",
+                "stream_type": "metrics",
+                "x": [],
+                "y": [],
+                "z": [],
+                "breakdown": [],
+                "filter": {
+                  "filterType": "group",
+                  "logicalOperator": "AND",
+                  "conditions": []
+                }
+              },
+              "config": {
+                "promql_legend": "{vcs_ref_head_name}",
+                "layer_type": "scatter",
+                "weight_fixed": 1,
+                "limit": 0,
+                "min": 0,
+                "max": 100,
+                "time_shift": []
+              }
+            }
+          ],
+          "layout": {
+            "x": 96,
+            "y": 0,
+            "w": 96,
+            "h": 18,
+            "i": 2
+          },
+          "htmlContent": "",
+          "markdownContent": "",
+          "customChartContent": " // To know more about ECharts , \n// visit: https://echarts.apache.org/examples/en/index.html \n// Example: https://echarts.apache.org/examples/en/editor.html?c=line-simple \n// Define your ECharts 'option' here. \n// 'data' variable is available for use and contains the response data from the search result and it is an array.\noption = {  \n \n};\n  "
+        },
+        {
+          "id": "Panel_ID1758410",
+          "type": "gauge",
+          "title": "Open Pull Requests",
+          "description": "",
+          "config": {
+            "show_legends": true,
+            "legends_position": null,
+            "decimals": 0,
+            "line_thickness": 1.5,
+            "step_value": "0",
+            "top_results_others": false,
+            "axis_border_show": false,
+            "label_option": {
+              "rotate": 0
+            },
+            "show_symbol": false,
+            "line_interpolation": "smooth",
+            "legend_width": {
+              "unit": "px"
+            },
+            "legend_height": {
+              "unit": "px"
+            },
+            "base_map": {
+              "type": "osm"
+            },
+            "map_type": {
+              "type": "world"
+            },
+            "map_view": {
+              "zoom": 1,
+              "lat": 0,
+              "lng": 0
+            },
+            "map_symbol_style": {
+              "size": "by Value",
+              "size_by_value": {
+                "min": 1,
+                "max": 100
+              },
+              "size_fixed": 2
+            },
+            "drilldown": [],
+            "mark_line": [],
+            "override_config": [],
+            "connect_nulls": false,
+            "no_value_replacement": "",
+            "wrap_table_cells": false,
+            "table_transpose": false,
+            "table_dynamic_columns": false,
+            "mappings": [],
+            "color": {
+              "mode": "continuous-green-yellow-red",
+              "fixedColor": [
+                "green",
+                "yellow",
+                "red"
+              ],
+              "seriesBy": "last",
+              "colorBySeries": []
+            },
+            "trellis": {
+              "layout": null,
+              "num_of_columns": 1,
+              "group_by_y_axis": false
+            },
+            "show_gridlines": true
+          },
+          "queryType": "promql",
+          "queries": [
+            {
+              "query": "vcs_change_count{vcs_repository_name=~\"$repo\", vcs_change_state=\"open\"}",
+              "vrlFunctionQuery": "",
+              "customQuery": true,
+              "fields": {
+                "stream": "vcs_change_count",
+                "stream_type": "metrics",
+                "x": [],
+                "y": [],
+                "z": [],
+                "breakdown": [],
+                "filter": {
+                  "filterType": "group",
+                  "logicalOperator": "AND",
+                  "conditions": []
+                }
+              },
+              "config": {
+                "promql_legend": "{vcs_change_state}",
+                "layer_type": "scatter",
+                "weight_fixed": 1,
+                "limit": 0,
+                "min": 0,
+                "max": 20,
+                "time_shift": []
+              }
+            }
+          ],
+          "layout": {
+            "x": 0,
+            "y": 0,
+            "w": 96,
+            "h": 18,
+            "i": 3
+          },
+          "htmlContent": "",
+          "markdownContent": "",
+          "customChartContent": " // To know more about ECharts , \n// visit: https://echarts.apache.org/examples/en/index.html \n// Example: https://echarts.apache.org/examples/en/editor.html?c=line-simple \n// Define your ECharts 'option' here. \n// 'data' variable is available for use and contains the response data from the search result and it is an array.\noption = {  \n \n};\n  "
+        },
+        {
+          "id": "Panel_ID4830110",
+          "type": "gauge",
+          "title": "Open PR Age",
+          "description": "",
+          "config": {
+            "show_legends": true,
+            "legends_position": null,
+            "unit": "seconds",
+            "decimals": 0,
+            "line_thickness": 1.5,
+            "step_value": "0",
+            "top_results_others": false,
+            "axis_border_show": false,
+            "label_option": {
+              "rotate": 0
+            },
+            "show_symbol": false,
+            "line_interpolation": "smooth",
+            "legend_width": {
+              "unit": "px"
+            },
+            "legend_height": {
+              "unit": "px"
+            },
+            "base_map": {
+              "type": "osm"
+            },
+            "map_type": {
+              "type": "world"
+            },
+            "map_view": {
+              "zoom": 1,
+              "lat": 0,
+              "lng": 0
+            },
+            "map_symbol_style": {
+              "size": "by Value",
+              "size_by_value": {
+                "min": 1,
+                "max": 100
+              },
+              "size_fixed": 2
+            },
+            "drilldown": [],
+            "mark_line": [],
+            "override_config": [],
+            "connect_nulls": false,
+            "no_value_replacement": "",
+            "wrap_table_cells": false,
+            "table_transpose": false,
+            "table_dynamic_columns": false,
+            "mappings": [],
+            "color": {
+              "mode": "palette-classic-by-series",
+              "fixedColor": [
+                "#53ca53"
+              ],
+              "seriesBy": "last",
+              "colorBySeries": []
+            },
+            "trellis": {
+              "layout": null,
+              "num_of_columns": 1,
+              "group_by_y_axis": false
+            },
+            "show_gridlines": true
+          },
+          "queryType": "promql",
+          "queries": [
+            {
+              "query": "vcs_change_duration{vcs_repository_name=~\"$repo\", vcs_change_state=\"open\"}",
+              "vrlFunctionQuery": "",
+              "customQuery": true,
+              "fields": {
+                "stream": "vcs_change_duration",
+                "stream_type": "metrics",
+                "x": [],
+                "y": [],
+                "z": [],
+                "breakdown": [],
+                "filter": {
+                  "filterType": "group",
+                  "logicalOperator": "AND",
+                  "conditions": []
+                }
+              },
+              "config": {
+                "promql_legend": "{vcs_ref_head_name}",
+                "layer_type": "scatter",
+                "weight_fixed": 1,
+                "limit": 0,
+                "min": 0,
+                "max": 604800,
+                "time_shift": []
+              }
+            }
+          ],
+          "layout": {
+            "x": 0,
+            "y": 38,
+            "w": 96,
+            "h": 18,
+            "i": 4
+          },
+          "htmlContent": "",
+          "markdownContent": "",
+          "customChartContent": " // To know more about ECharts , \n// visit: https://echarts.apache.org/examples/en/index.html \n// Example: https://echarts.apache.org/examples/en/editor.html?c=line-simple \n// Define your ECharts 'option' here. \n// 'data' variable is available for use and contains the response data from the search result and it is an array.\noption = {  \n \n};\n  "
+        }
+      ]
+    }
+  ],
+  "variables": {
+    "list": [
+      {
+        "type": "query_values",
+        "name": "repo",
+        "label": "Repository",
+        "query_data": {
+          "stream_type": "metrics",
+          "stream": "vcs_ref_count",
+          "field": "vcs_repository_name",
+          "max_record_size": null,
+          "filter": []
+        },
+        "value": "",
+        "options": [
+          {
+            "label": "",
+            "value": "",
+            "selected": true
+          }
+        ],
+        "multiSelect": false,
+        "hideOnDashboard": false,
+        "selectAllValueForMultiSelect": "first",
+        "customMultiSelectValue": [],
+        "escapeSingleQuotes": false
+      }
+    ],
+    "showDynamicFilters": true
+  },
+  "defaultDatetimeDuration": {
+    "type": "relative",
+    "relativeTimePeriod": "15m"
+  }
+}

--- a/apps/openobserve/kustomization.yaml
+++ b/apps/openobserve/kustomization.yaml
@@ -7,4 +7,14 @@ namespace: openobserve
 resources:
   - ../../cluster-infra/namespace/
   - sts.yaml
+  - secret.yaml
+  - dashboard-bootstrap-job.yaml
+
+configMapGenerator:
+  - name: openobserve-dashboards
+    files:
+      - dashboards/engineering-effectiveness.dashboard.json
+
+generatorOptions:
+  disableNameSuffixHash: true
 

--- a/apps/openobserve/secret.yaml
+++ b/apps/openobserve/secret.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: openobserve-creds
+  namespace: openobserve
+type: Opaque
+stringData:
+  OO_USER: "root@example.com"
+  OO_PASSWORD: "Complexpass#123"
+  OO_ORG: "default"

--- a/apps/openobserve/sts.yaml
+++ b/apps/openobserve/sts.yaml
@@ -46,9 +46,15 @@ spec:
           image: public.ecr.aws/zinclabs/openobserve:latest
           env:
             - name: ZO_ROOT_USER_EMAIL
-              value: root@example.com
+              valueFrom:
+                secretKeyRef:
+                  name: openobserve-creds
+                  key: OO_USER
             - name: ZO_ROOT_USER_PASSWORD
-              value: Complexpass#123
+              valueFrom:
+                secretKeyRef:
+                  name: openobserve-creds
+                  key: OO_PASSWORD
             - name: ZO_DATA_DIR
               value: /data
             - name: ZO_TRACES_FILE_RETENTION

--- a/collectors/base/collector.yaml
+++ b/collectors/base/collector.yaml
@@ -4,5 +4,5 @@ kind: OpenTelemetryCollector
 metadata:
   name: collector
 spec:
-  image: ghcr.io/liatrio/liatrio-otel-collector:0.97.0-amd64
+  image: ghcr.io/liatrio/liatrio-otel-collector:0.97.2-amd64
   mode: deployment

--- a/collectors/gateway/colconfig.yaml
+++ b/collectors/gateway/colconfig.yaml
@@ -76,16 +76,16 @@
         # tls:
         #   insecure: true
 
-      clickhouse:
-        endpoint: http://hyperdx-hdx-oss-v2-clickhouse.clickstack.svc.cluster.local:8123
-        username: otelcollector
-        password: otelcollectorpass
-        timeout: 5s
-        retry_on_failure:
-          enabled: true
-          initial_interval: 5s
-          max_interval: 30s
-          max_elapsed_time: 300s
+      # clickhouse:
+      #   endpoint: http://hyperdx-hdx-oss-v2-clickhouse.clickstack.svc.cluster.local:8123
+      #   username: otelcollector
+      #   password: otelcollectorpass
+      #   timeout: 5s
+      #   retry_on_failure:
+      #     enabled: true
+      #     initial_interval: 5s
+      #     max_interval: 30s
+      #     max_elapsed_time: 300s
 
     service:
       # extensions: [health_check, pprof, zpages]
@@ -101,7 +101,7 @@
           exporters:
             - debug
             - otlphttp/openobserve
-            - clickhouse
+            # - clickhouse
 
         logs:
           receivers:
@@ -113,7 +113,7 @@
           exporters:
             - debug
             - otlphttp/openobserve
-            - clickhouse
+            # - clickhouse
 
         traces:
           receivers:
@@ -125,4 +125,4 @@
           exporters:
             - debug
             - otlphttp/openobserve
-            - clickhouse
+            # - clickhouse


### PR DESCRIPTION
This pull request introduces a new OpenObserve deployment with automated dashboard bootstrapping, updates secret management for credentials, and makes several improvements and fixes to deployment and collector configurations. The most significant changes are grouped below.

## Fixes

**Collector and Gateway Configuration:**

* Updated the OpenTelemetry Collector image version from `0.97.0-amd64` to `0.97.2-amd64` for all collectors.
* Commented out the ClickHouse exporter configuration in the gateway collector to disable it, likely for troubleshooting or migration purposes. Clickhouse was partially removed but not from the config creating errors. [[1]](diffhunk://#diff-923420e9300d2a2effb096ed24a183f1156f29c50cde5b55cf7de14075c88fdeL79-R88) [[2]](diffhunk://#diff-923420e9300d2a2effb096ed24a183f1156f29c50cde5b55cf7de14075c88fdeL104-R104) [[3]](diffhunk://#diff-923420e9300d2a2effb096ed24a183f1156f29c50cde5b55cf7de14075c88fdeL116-R116) [[4]](diffhunk://#diff-923420e9300d2a2effb096ed24a183f1156f29c50cde5b55cf7de14075c88fdeL128-R128)

**Deployment Makefile Improvements:**

* Updated Makefile targets for GitHub, GitLab, and Dora collectors to use environment variables and depend on the `default` target, streamlining deployment logic. We had a central Tilt file that was expecting envs but the Makefile was not setting anything. Thus do deploy flavors of the app (dora and ghr you were left in a weird state that didn't get you the benefit of Tilt) [[1]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L57-R61) [[2]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L78-R79)

## Features

**Notes
The bootstrapping method is a hack b/c openobserve does not yet support this feature (they want to but not on the roadmap) https://github.com/openobserve/openobserve/issues/7073

**OpenObserve Deployment and Dashboard Bootstrapping:**

* Added a new `apps/openobserve` deployment with a `README.md` explaining setup, dashboard provisioning, and troubleshooting. This includes instructions for exporting/importing dashboards and details on file structure and configuration.
* Implemented a Kubernetes Job (`dashboard-bootstrap-job.yaml`) that automatically imports dashboards from JSON files into OpenObserve on startup, with dashboard files managed via a ConfigMap. [[1]](diffhunk://#diff-f02b7509eecbbdf0c9fd98fa0ae9ecf59cb350c07fb4cec2e529be6ad07ca6e3R1-R69) [[2]](diffhunk://#diff-3970d25eed62c33f6f12d7fcc8bacfa04ab6c5b78e9554239e2611c2adf0b21fR10-R19)
* Added a `Tiltfile` to automate resource creation, manage resource dependencies, and ensure the dashboard bootstrap job runs after OpenObserve is ready.

**Credential and Secret Management:**

* Switched OpenObserve root credentials in the StatefulSet to use Kubernetes Secrets (`openobserve-creds`), improving security and configurability. [[1]](diffhunk://#diff-2f54a1092fd9f6e6861e8c1b99881c9f5a08bd97995a323ed3f1039b747a0b90R1-R10) [[2]](diffhunk://#diff-928fbfd219f4adb1248e68c33a9663a1fabb97dc3f748904c71dd0a6001f03d8L49-R57)


